### PR TITLE
No need to always update the Samples

### DIFF
--- a/Model/lib/xml/tuningManager/studyTuningManager.xml
+++ b/Model/lib/xml/tuningManager/studyTuningManager.xml
@@ -1350,12 +1350,13 @@ UNION ALL
     </sql>
   </tuningTable>
 
-  <tuningTable name="Samples" alwaysUpdate="true" prefixEnabled="true">
+  <tuningTable name="Samples" prefixEnabled="true">
     <comment>lots of columns for sample meta data. used for sample record
       </comment>
     <internalDependency name="InferredParams"/>
     <internalDependency name="PropertyType"/>
     <externalDependency name="sres.OntologyTerm"/>
+    <externalDependency name="study.ProtocolAppNode"/>
     <ancillaryTable name="Participants"/>
     <ancillaryTable name="Observations"/>
     <ancillaryTable name="LightTraps"/>


### PR DESCRIPTION
Instead, list the source tables from buildSampleAttributesTT as dependencies. The program only refers to tables - no randomness, no reading files, etc. so I don't see why we don't let tuning manager decide whether to update it or not.

The change will save me about 187 seconds each time I run the tuning manager, and maybe not break anything for anyone unless I'm missing a reason for this alwaysUpdate="true".