### PR TITLE
MicrobiomeDB17

### DIFF
--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -1318,27 +1318,78 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
 
   </datasetClass>
 
-  <datasetClass class="NASeqFromFasta" category="" datasetFileHint="">
-    <purpose></purpose>
+  <datasetClass class="rRNAReference" category="" datasetFileHint="">
+    <purpose>Assign OTUs to experimental rRNA sequences</purpose>
     <prop name="projectName">&projectName;</prop>
     <prop name="name">&name;</prop>
     <prop name="version">&version;</prop>
-    <prop name="soTermName"/>
 
     <graphTemplateFile name="microbiomeRoot.xml"/>
 
-    <datasetLoader datasetName="NASeqFromFasta_${name}_RSRC"
+    <datasetLoader datasetName="rRNAReference_RSRC"
 	      version="${version}"
-	      plugin="ApiCommonData::Load::Plugin::LoadNASequencesFromFasta"
+	      plugin="ApiCommonData::Load::Plugin::LoadNothing"
               scope="global"
               type="sres"
              >
-      <manualGet fileOrDir="${projectName}/common/NASeqFromFasta/${name}/${version}/final/sequences.fsa">
+
+      <manualGet fileOrDir="common/empty">
         <dir name="final">
         </dir>
       </manualGet>
+      <unpack> mkdir -pv @@dataDir@@ </unpack>
+      <unpack> cp @@manualDeliveryDir@@/${projectName}/common/rRNAReference/${name}/${version}/final/training_set.${version}.fa.gz @@dataDir@@/trainingSet.fa.gz </unpack>
+      <unpack> cp @@manualDeliveryDir@@/${projectName}/common/rRNAReference/${name}/${version}/final/species_assignment.${version}.fa.gz @@dataDir@@/speciesAssignment.fa.gz </unpack>
 
-      <pluginArgs> --fastaFile  @@dataDir@@/sequences.fsa --externalDatabaseName  %DATASET_NAME% --externalDatabaseVersion %DATASET_VERSION% --SOTermName ${soTermName}  --SOExtDbRlsSpec 'SO_RSRC|%'</pluginArgs>
+      <pluginArgs></pluginArgs>
+    </datasetLoader>
+  </datasetClass>
+
+  <datasetClass class="rRNAExperiment" category="" datasetFileHint="">
+    <purpose>Copy the manual delivery files</purpose>
+    <prop name="projectName">&projectName;</prop>
+    <prop name="name"/>
+    <prop name="version"/>
+    <prop name="samplesInfoFile"/>
+
+    <graphTemplateFile name="microbiomeRoot.xml"/>
+
+    <datasetLoader datasetName="otuDADA2_${name}_RSRC" version="${version}"
+              plugin="ApiCommonData::Load::Plugin::LoadNothing"
+              type="population_biology"
+              scope="global"
+            >
+<!-- Also this used to copy a file, analysisConfig.xml --> 
+      <manualGet fileOrDir="${projectName}/common/otu/${name}/${version}/final/">
+        <dir name="final">
+        </dir>
+      </manualGet>
+      <unpack>if [ $( find @@manualDeliveryDir@@/${projectName}/common/otu/${name}/${version}/final/ | wc -l ) -ne $( find @@dataDir@@/final/ | wc -l ) ] ; then echo "Not all copied?"; exit 1; fi </unpack>
+      <unpack>mv @@dataDir@@/final/ @@dataDir@@/fastqsFromManualDelivery/</unpack>
+      <unpack>find @@dataDir@@/fastqsFromManualDelivery -type f -not \( -name '*.fq.gz' -o -name '*.fq' -o -name '*.fastq.gz' -o -name '*.fastq' \) -delete  </unpack>
+      <unpack>rmdir -v --ignore-fail-on-non-empty @@dataDir@@/fastqsFromManualDelivery</unpack>
+      <unpack>if test "${samplesInfoFile}" ; then cp @@manualDeliveryDir@@/${projectName}/common/otu/${name}/${version}/final/${samplesInfoFile} @@dataDir@@/${samplesInfoFile} ; fi </unpack>
+      
+      <pluginArgs></pluginArgs>
+    </datasetLoader>
+  </datasetClass>
+
+
+  <datasetClass class="lineageTaxonLinkingTable" category="" datasetFileHint="">
+    <purpose>Create a lineage taxon linking table after the taxonomy and the results are in the database</purpose>
+
+    <graphTemplateFile name="microbiomeRoot.xml"/>
+   
+    <datasetLoader datasetName="LineageTaxonLinkingTable_RSRC" version="dontcare"
+              plugin="ApiCommonData::Load::LineageTaxonLinkingTable"
+              type="sres"
+              scope="global"
+            >
+      <manualGet fileOrDir="common/empty">
+        <dir name="final">
+        </dir>
+      </manualGet>
+      <pluginArgs></pluginArgs>
     </datasetLoader>
   </datasetClass>
 
@@ -4126,96 +4177,6 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
       <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
     </datasetLoader>
   </datasetClass>
-
-  <datasetClass class="otuProfiles" category="" datasetFileHint="">
-    <purpose></purpose>
-    <prop name="projectName">&projectName;</prop>
-    <prop name="name"/>
-    <prop name="version"/>
-
-    <graphTemplateFile name="microbiomeRoot.xml"/>
-   
-    <datasetLoader datasetName="otu_${name}_RSRC" version="${version}"
-              plugin="ApiCommonData::Load::Plugin::LoadNothing"
-              type="population_biology"
-              scope="global"
-            >
-
-      <manualGet fileOrDir="${projectName}/common/otu/${name}/${version}/final/">
-        <dir name="final">
-        </dir>
-      </manualGet>
-      <getAndUnpackOutput dir="@@dataDir@@/final"/>
-      <getAndUnpackOutput file="@@dataDir@@/final/analysisConfig.xml"/>
-      <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
-    </datasetLoader>
-  </datasetClass>
-
-
-  <datasetClass class="otuProfilesDADA2" category="" datasetFileHint="">
-    <purpose></purpose>
-    <prop name="projectName">&projectName;</prop>
-    <prop name="name"/>
-    <prop name="version"/>
-    <prop name="multiplexed"/>
-    <prop name="barcodesType"/>
-    <prop name="samplesInfoFile"/>
-    <prop name="isPaired"/>
-    <prop name="trimLeft"/>
-    <prop name="trimLeftR"/>
-    <prop name="truncLen"/>
-    <prop name="truncLenR"/>
-    <prop name="readLen"/>
-    <prop name="platform"/>
-    <prop name="sraStudyId"/>
-    <prop name="mergeTechReps"/>
-
-    <graphTemplateFile name="microbiomeRoot.xml"/>
-
-    <datasetLoader datasetName="otuDADA2_${name}_RSRC" version="${version}"
-              plugin="ApiCommonData::Load::Plugin::LoadNothing"
-              type="population_biology"
-              scope="global"
-            >
-
-      <manualGet fileOrDir="${projectName}/common/otu/${name}/${version}/final/">
-        <dir name="final">
-        </dir>
-      </manualGet>
-      <getAndUnpackOutput dir="@@dataDir@@/final"/>
-      <getAndUnpackOutput file="@@dataDir@@/final/analysisConfig.xml"/>
-      <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
-    </datasetLoader>
-  </datasetClass>
-
-
-  <datasetClass class="taxonMapping" category="" datasetFileHint="">
-    <purpose></purpose>
-    <prop name="projectName">&projectName;</prop>
-    <prop name="name"/>
-    <prop name="version"/>
-
-    <graphTemplateFile name="microbiomeRoot.xml"/>
-   
-    <datasetLoader datasetName="taxonMapping_${name}_RSRC" version="${version}"
-              plugin="ApiCommonData::Load::Plugin::InsertSequenceTaxon"
-              type="sres"
-              scope="global"
-            >
-
-      <manualGet fileOrDir="${projectName}/common/curatedTaxonomy/${name}/${version}/final/">
-        <dir name="final">
-        </dir>
-      </manualGet>
-
-      <getAndUnpackOutput dir="@@dataDir@@/final"/>
-      <getAndUnpackOutput file="@@dataDir@@/final/sequenceToTaxonHierarchy.txt"/> <!-- maps na_sequence source_id to a string -->
-      <getAndUnpackOutput file="@@dataDir@@/final/taxonMapping.xml"/> <!-- manual override string to ncbi taxonomy -->
-
-      <pluginArgs>--dbRlsSpec "%DATASET_NAME%|%DATASET_VERSION%" --sequenceToTaxonHierarchyFile @@dataDir@@/final/sequenceToTaxonHierarchy.txt --taxonMappingFile @@dataDir@@/final/taxonMapping.xml</pluginArgs>
-    </datasetLoader>
-  </datasetClass>
-
   <datasetClass class="phylogeneticProfiles" category="" datasetFileHint="">
     <purpose></purpose>
     <prop name="projectName">&projectName;</prop>

--- a/Model/lib/xml/tuningManager/studyTuningManager.xml
+++ b/Model/lib/xml/tuningManager/studyTuningManager.xml
@@ -219,8 +219,7 @@
     <externalDependency name="results.RnaExpression"/>
     <externalDependency name="results.SegmentDiffResult"/>
     <externalDependency name="results.SeqVariation"/>
-    <externalDependency name="results.OtuAbundance"/>
-    <externalDependency name="results.AlphaDiversity"/>
+    <externalDependency name="results.LineageAbundance"/>
     <externalDependency name="apidb.SequenceVariation"/>
     <externalDependency name="apidb.MassSpecSummary"/>
     <externalDependency name="apidb.ChrCopyNumber"/>
@@ -288,11 +287,8 @@
     select protocol_app_node_id, 'Results::RnaExpression' as result_table from study.ProtocolAppNode
       where protocol_app_node_id in (select protocol_app_node_id from Results.RnaExpression)
       union
-    select protocol_app_node_id, 'Results::OtuAbundance' as result_table from study.ProtocolAppNode
-      where protocol_app_node_id in (select protocol_app_node_id from Results.OtuAbundance)
-    union
-    select protocol_app_node_id, 'Results::AlphaDiversity' as result_table from study.ProtocolAppNode
-      where protocol_app_node_id in (select protocol_app_node_id from Results.AlphaDiversity)
+    select protocol_app_node_id, 'Results::LineageAbundance' as result_table from study.ProtocolAppNode
+      where protocol_app_node_id in (select protocol_app_node_id from Results.LineageAbundance)
     union
     select protocol_app_node_id, 'Results::SegmentDiffResult' as result_table from study.ProtocolAppNode
       where protocol_app_node_id in (select protocol_app_node_id from Results.SegmentDiffResult)

--- a/Model/lib/xml/tuningManager/tuningManager.xml
+++ b/Model/lib/xml/tuningManager/tuningManager.xml
@@ -4,7 +4,7 @@
   <import file="studyTuningManager.xml"/>
 
   <tuningTable name="ExternalSequenceTaxonRank" prefixEnabled="false">
-    <comment>Taxon ranks for 16S reference organisms
+    <comment>Taxon ranks for sequences
     </comment>
     <externalDependency name="apidb.TaxonString"/>
     <externalDependency name="dots.ExternalNaSequence"/>
@@ -69,183 +69,115 @@ order by organism, species, genus
   </tuningTable>
 
   <tuningTable name="TaxonAbundance" prefixEnabled="false">
-    <comment>otu relative abundance values, aggegated at various taxonomic levels
-    </comment>
-    <externalDependency name="apidb.Datasource"/>
-    <externalDependency name="results.OtuAbundance"/>
+    <comment>lineage abundances</comment>
+    <externalDependency name="results.LineageAbundance"/>
+    <externalDependency name="results.LineageTaxon"/>
     <externalDependency name="sres.ExternalDatabase"/>
     <externalDependency name="sres.ExternalDatabaseRelease"/>
     <externalDependency name="study.ProtocolAppNode"/>
-    <externalDependency name="study.Study"/>
     <externalDependency name="study.StudyLink"/>
-    <internalDependency name="ExternalSequenceTaxonRank"/>
+    <externalDependency name="study.Study"/>
     <sql>
       <![CDATA[
-        CREATE TABLE TaxonAbundance&1 NOLOGGING AS
-        WITH leaf_abundance
-        AS (SELECT oa.protocol_app_node_id, oa.raw_count AS raw_count,
-                   oa.relative_abundance AS relative_abundance, 
-                   oa.taxon_id as taxon_id
-            FROM results.OtuAbundance oa
-            WHERE oa.relative_abundance is not null
-           ),
-        taxa_string_map
-        AS (  SELECT DECODE(REPLACE(estr.kingdom, 'N/A', 'unknown'), 'unknown',
-                            REPLACE(estr.superkingdom, 'N/A', 'unknown'), estr.kingdom) AS taxon_string
-                     , 'kingdom' AS taxon_node
-                     , nvl(kingdom_id, superkingdom_id) AS taxon_id
-                     , 1 AS taxon_level
-                     , la.protocol_app_node_id
-                     , la.relative_abundance
-                     , la.raw_count
-              FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT REPLACE(estr.phylum, 'N/A', 'unknown') AS taxon_string
-                     , 'phylum' AS taxon_node
-                     , phylum_id AS taxon_id
-                     , 2 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-              FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT REPLACE(estr.class, 'N/A', 'unknown') AS taxon_string
-                     , 'class' AS taxon_node
-                     , class_id AS taxon_id
-                     , 3 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-                FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT replace(estr.rank_order, 'N/A', 'unknown')as taxon_string
-                     , 'order' AS taxon_node
-                     , rank_order_id AS taxon_id
-                     , 4 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-                FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT replace(estr.family, 'N/A', 'unknown') AS taxon_string
-                     , 'family' AS taxon_node
-                     , family_id AS taxon_id
-                     , 5 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-                FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT replace(estr.genus, 'N/A', 'unknown') AS taxon_string
-                     , 'genus' AS taxon_node
-                     , genus_id AS taxon_id
-                     , 6 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-              FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-            UNION
-              SELECT replace(estr.species, 'N/A', 'unknown') AS taxon_string
-                     , 'species' AS taxon_node
-                     , species_id AS taxon_id
-                     , 7 AS taxon_level
-                     , la.protocol_app_node_id,la.relative_abundance
-                     , la.raw_count
-              FROM ExternalSequenceTaxonRank estr, leaf_abundance la
-              WHERE estr.organism = la.taxon_id
-           ),
-        agg_taxon_string_map
-        AS (SELECT taxon_string AS taxon_name, taxon_node,
-                   taxon_node || '|' || taxon_id AS taxon_id, taxon_level,
-                   protocol_app_node_id, SUM(relative_abundance) AS relative_abundance,
-                   SUM(raw_count) AS raw_count
-            FROM taxa_string_map
-            GROUP BY taxon_string, taxon_node, taxon_node || '|' || taxon_id,
-                     taxon_level, protocol_app_node_id
-           )
-        SELECT tsm.protocol_app_node_id, pan.name AS pan_name,
-               initcap(tsm.taxon_node) AS category, CAST(tsm.taxon_name AS VARCHAR2(200)) AS term,
-               tsm.taxon_id AS term_id, ds.name AS dataset_name, ds.type, ds.subtype,
-               study_release.study_name, study_release.investigation_name,
-               tsm.taxon_level, tsm.raw_count AS agg_count,
-               round(tsm.relative_abundance, 6) AS value
-        FROM agg_taxon_string_map tsm,
+       CREATE TABLE TaxonAbundance&1 NOLOGGING AS
+       WITH abundance as (
+         select la.protocol_app_node_id,
+         'Kingdom' as category,
+         1 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\1') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+       UNION
+         select la.protocol_app_node_id,
+         'Phylum' as category,
+         2 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\2') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') >= 1
+       UNION
+         select la.protocol_app_node_id,
+         'Class' as category,
+         3 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\3') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') >= 2
+       UNION
+         select la.protocol_app_node_id,
+         'Order' as category,
+         4 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\4') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') >= 3
+       UNION
+         select la.protocol_app_node_id,
+         'Family' as category,
+         5 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\5') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') >= 4
+       UNION
+         select la.protocol_app_node_id,
+         'Genus' as category,
+         6 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\6') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') >= 5
+       UNION
+         select la.protocol_app_node_id,
+         'Species' as category,
+         7 as taxon_level,
+         regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\7') as term,
+         la.raw_count,
+         la.relative_abundance
+         from results.LineageAbundance la
+         where REGEXP_COUNT(la.lineage, ';') = 6
+       )
+       SELECT  
+               abundance.protocol_app_node_id,
+               abundance.category,
+               abundance.taxon_level,
+               abundance.term,
+               sum(abundance.raw_count) as agg_count,
+               sum(abundance.relative_abundance) as value,
+               pan.name AS pan_name,
+               ed.name AS dataset_name
+        FROM
+             abundance,
              study.ProtocolAppNode pan,
              study.StudyLink sl,
+             study.Study ss,
              sres.ExternalDatabaseRelease edr,
-             sres.ExternalDatabase ed,
-             apidb.Datasource ds,
-             (SELECT s.study_id, i.external_database_release_id,
-                     s.name AS study_name, i.name AS investigation_name
-              FROM study.Study s, study.Study i
-              WHERE s.investigation_id = i.study_id
-                AND s.name not like '%[%]%'
-                AND i.name like 'OTU Profile%'
-              ) study_release
-        WHERE tsm.protocol_app_node_id = pan.protocol_app_node_id
-          AND tsm.protocol_app_node_id = sl.protocol_app_node_id
-          AND sl.study_id = study_release.study_id
-          AND study_release.external_database_release_id = edr.external_database_release_id
+             sres.ExternalDatabase ed
+        WHERE abundance.protocol_app_node_id = pan.protocol_app_node_id
+          AND pan.protocol_app_node_id = sl.protocol_app_node_id
+          AND sl.study_id = ss.study_id
+          AND ss.name not like 'OTU Profiles%'
+          AND ss.external_database_release_id = edr.external_database_release_id
           AND edr.external_database_id = ed.external_database_id
-          AND ed.name = ds.name
-        ORDER BY type, subtype, study_name, dataset_name, pan_name
+          AND ed.name like 'otu%_RSRC'
+        GROUP BY (abundance.protocol_app_node_id, abundance.category, abundance.taxon_level, abundance.term, pan.name, ed.name)
+        ORDER BY dataset_name, pan_name
       ]]>
     </sql>
     <sql>
       <![CDATA[
         CREATE UNIQUE INDEX TaxAbund_panId_Term&1
-          ON TaxonAbundance&1 (protocol_app_node_id, term_id,  category, term)
+          ON TaxonAbundance&1 (protocol_app_node_id, category, term)
           TABLESPACE INDX
       ]]>
     </sql>
   </tuningTable>
-
-
-
-
-
-
-
-
-  <tuningTable name="TaxonAbundanceSpec">
-    <internalDependency name="TaxonAbundance"/>
-    <sql>
-      <![CDATA[
-       create table TaxonAbundanceSpec&1 nologging as
-        -- parent
-          select  type, subtype, dataset_name,  term_id as property, 'parent' as spec_property, category as spec_value, taxon_level
-          from TaxonAbundance
-        --grandparent
-        union
-          select  type, subtype, dataset_name, category as property, 'parent' as spec_property, null as spec_value, taxon_level
-          from TaxonAbundance
-        -- leaf
-        union
-          select type, subtype, dataset_name,  term_id as property, 'leaf' as spec_property, 'true' as spec_value, taxon_level
-          from TaxonAbundance
-        -- filter
-        union
-          select type, subtype, dataset_name,
-                 term_id as property, 'filter' as spec_property, 'range' as spec_value, taxon_level
-          from TaxonAbundance
-        -- display
-        union
-          select distinct type, subtype, dataset_name, term_id as property, 'display' as spec_property, term as spec_value, taxon_level
-          from TaxonAbundance
-        -- parent:display
-        union
-          select distinct type, subtype, dataset_name, category as property, 'display' as spec_property, category as spec_value, taxon_level
-          from TaxonAbundance
-        -- type
-        union
-          select type, subtype, dataset_name, term_id as property, 'type' as spec_property, 'number' as spec_value, taxon_level
-          from TaxonAbundance
-        order by 1, 2, 3
-      ]]>
-    </sql>
-  </tuningTable>
-
 
   <tuningTable name="ProjectTaxon" prefixEnabled="true">
     <comment>map taxon names onto project_ids. to be used by the apidb.project_id function</comment>
@@ -613,39 +545,54 @@ create unique index SeqAttr_naseqid&1 ON &prefixGenomicSeqAttributes&1 (na_seque
   <tuningTable name="TaxonRelativeAbundance">
     <comment>for the sample record taxon relative abundance table
      </comment>
+    <externalDependency name="results.LineageAbundance"/>
+    <externalDependency name="results.LineageTaxon"/>
     <externalDependency name="sres.Taxon"/>
-    <externalDependency name="results.OtuAbundance"/>
     <internalDependency name="InferredParams"/>
-    <internalDependency name="ExternalSequenceTaxonRank"/>
     <sql>
       <![CDATA[
         create table TaxonRelativeAbundance&1
-            (name, protocol_app_node_id, taxon_id, relative_abundance, 
-             absolute_abundance, ncbi_tax_id, kingdom, phylum, class, 
+            (name, protocol_app_node_id, relative_abundance,
+             absolute_abundance, ncbi_tax_id, lineage, kingdom, phylum, class,
              rank_order, family, genus, species,
-             constraint taxRelAbund&1_pk primary key(name, taxon_id))
-        organization index
+             constraint taxRelAbund&1_pk primary key(name, lineage))
         nologging
-        as select ta.*, t.ncbi_tax_id,
-                  replace(decode(superkingdom, 'N/A', kingdom, superkingdom), 'N/A', '') as kingdom,
-                  replace(phylum, 'N/A', '') as phylum,
-                  replace(class, 'N/A', '') as class,
-                  replace(rank_order, 'N/A', '') as rank_order,
-                  replace(family, 'N/A', '') as family,
-                  replace(genus, 'N/A', '') as genus,
-                  replace(species, 'N/A', '') as species
-           from (select ds.name, oa.protocol_app_node_id, oa.taxon_id,
-                        sum(nvl(oa.relative_abundance, 0)) as relative_abundance,
-                        sum(nvl(oa.raw_count, 0)) as absolute_abundance
-                 from results.OtuAbundance oa, sampleprocess ds
-                 where oa.protocol_app_node_id = ds.output_pan_id
-                   and ds.output_isa_type = 'Data'
-                 group by ds.name, oa.protocol_app_node_id, oa.taxon_id
-                ) ta,
-                ExternalSequenceTaxonRank estr, sres.Taxon t
-           where ta.taxon_id = estr.organism
-             and ta.relative_abundance > 0
-             and ta.taxon_id = t.taxon_id
+        as SELECT
+           sp.name,
+           la.protocol_app_node_id,
+           la.relative_abundance,
+           la.raw_count as absolute_abundance,
+           st.ncbi_tax_id,
+           la.lineage,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\1') as kingdom,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\2') as phylum,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\3') as class,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\4') as rank_order,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\5') as family,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\6') as genus,
+           regexp_replace(la.lineage, '^([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?([^;]+)?;?$', '\7') as species
+        FROM
+             results.LineageAbundance la,
+             results.LineageTaxon lt,
+             sres.Taxon st,
+             apidbtuning.SampleProcess sp
+         WHERE la.lineage = lt.lineage (+)
+          AND lt.taxon_id = st.taxon_id (+)
+          AND la.protocol_app_node_id = sp.output_pan_id
+      ]]>
+    </sql>
+    <sql>
+      <![CDATA[
+        CREATE UNIQUE INDEX TaxRelAbund_uix&1
+          ON TaxonRelativeAbundance&1 (name, protocol_app_node_id, lineage)
+          TABLESPACE INDX
+      ]]>
+    </sql>
+    <sql>
+      <![CDATA[
+        CREATE INDEX TaxRelAbund_ncbi&1
+          ON TaxonRelativeAbundance&1 (ncbi_tax_id)
+          TABLESPACE INDX
       ]]>
     </sql>
   </tuningTable>


### PR DESCRIPTION
Microbiome datasets and tuning manager match the reworked workflow graph and schema

classes.xml:
- rRNAReference (was: NASeqFromFasta)
  + specific files copied instead of the whole folder
  + no longer loads the sequences
- rRNAExperiment (was: otuProfiles, otuProfilesDADA2)
  + copy only the fastqs and the samples info file, and only make the directory if there was a true manual delivery (stuff in the workflow later depends on it)
  + check everything got copied, bail if not (I've observed sometimes it didn't, possibly caused by erroneous workflow command)
- dummy class for ApiCommonData::Load::LineageTaxonLinkingTable
- remove class for InsertSequenceTaxon (which is gone too)

studyTuningManager:
- looks for studies in Results.LineageAbundance, not the previous Results.OtuAbundance

tuningManager.TaxonAbundance:
- constructed differently, using lineage strings as input
- doesn't have a cast of Term to VARCHAR(200) - ends up being a long varchar
- doesn't have seemingly unneeded columns: type, subtype, study_name, investigation_name
- speculatively doesn't use term_id - this was used for query by taxon abundance, but was changed to just term
- does not round up relative abundance to six figures - this is done in ApiCommonData::Load::LineageAbundances

tuningManager.TaxonRelativeAbundance:
- a unique index on name/protocol_app_node_id + lineage instead of being an all-index table because kingdom, phylum, etc. fields are large varchars - could be changed
- separate index on ncbi_tax_id should not be part of uniqueness because if there are many ncbi_tax_ids for a lineage something is terribly wrong
- does not have a seemingly unneeded column taxon_id
- does not sum abundances - done in DJob/DistribJobTasks/bin/dada2/mergeAsvsAndAssignToOtus.R
- does not filter on relative abundance > 0 - done in ApiCommonData::Load::LineageAbundances
- does not filter on ds.output_isa_type = 'Data' - it works out like that anyway because of the join

also tuningManager:
- Speculatively remove table TaxonAbundanceSpec
- ExternalSequenceTaxonRank is gone as an auxiliary tuning table