### PR TITLE
Make DownloadVersion links "restricted"

### DIFF
--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -323,7 +323,6 @@ OR if the linkName and or URL require access to other attributes....also how to 
 	<!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <!-- clinepi versioning download files table -->
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
-<!--
         <table name="DownloadVersion"  includeProjects="ClinEpiDB,Gates,AllClinEpiDB,ICEMR"
                displayName="Data Download Versions"
                queryRef="DatasetTables.DownloadVersion">
@@ -332,23 +331,27 @@ OR if the linkName and or URL require access to other attributes....also how to 
 
             <columnAttribute name="version_number" inReportMaker="false" internal="true"/>
 
-            <linkAttribute name="version_number_link" inReportMaker="false" internal="false"
+            <textAttribute name="version_number_link" inReportMaker="false" internal="false"
                            displayName="Download link">
-                 <displayText>
-                    <![CDATA[ 
-			     $$version_number$$                                                                                
-		    ]]>
-                 </displayText>
-                 <url>
-                    <![CDATA[ @WEBAPP_BASE_URL@/downloads/release-$$build_number$$/$$dataset_sha1_digest$$ ]]>
-                 </url>
-            </linkAttribute>
+              <text>
+                <![CDATA[
+                  <button
+                    type="button"
+                    class="study-action link"
+                    data-study-id="$$dataset_id$$"
+                    data-args='{
+                      "type": "download",
+                      "downloadUrl": "@WEBAPP_BASE_URL@/downloads/release-$$build_number$$/$$dataset_sha1_digest$$"
+                    }'
+                  >$$version_number$$</button>
+                ]]>
+              </text>
+            </textAttribute>
             <columnAttribute name="build_number" displayName="Release #"/>
             <columnAttribute name="release_date" displayName="Release Date"/>
             <columnAttribute name="note" displayName="Updates"/>
             <columnAttribute name="dataset_sha1_digest" internal="true"/>     
         </table>
--->
 
 
 
@@ -1105,7 +1108,6 @@ from apidbtuning.datasetnametaxon dsnt
       </sqlQuery>
 
 
-<!--
 <sqlQuery name="DownloadVersion" isCacheable='false' includeProjects="ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
             <column name="dataset_name"/>
             <column name="dataset_id"/>
@@ -1128,7 +1130,6 @@ FROM (
 	    ]]>
         </sql>
 </sqlQuery>
--->
 
 
 


### PR DESCRIPTION
This PR updates the `DownloadVersion` model so that the links it provides are now "restricted"; it makes use of some [new client functionality](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/38).

In general: to make a "restricted" link in the model, you can use a `textAttribute` which renders a `button` with the class `study-action` and two data attributes: `data-study-id` and `data-args`.

For example, the following html can be used to make a "restricted" link to the study `DS_a885240fc4` and associated download url `/href/to/some/download/page/for/DS_a885240fc4`:

```
<button
  type="button"
  class="study-action link" 
  data-study-id="DS_a885240fc4"
  data-args='{
    "type": "download",
    "downloadUrl": "/href/to/some/download/page/for/DS_a885240fc4"
  }'
>Click me!</button>
```

Note: the use of the `link` class is optional - it is used to style a button as though it were a link. (Which is what we want for this specific table.)