### PR TITLE
Cleanup - dataset record pages and search

### DIFF
--- a/Model/lib/wdk/model/questions/queries/datasetQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/datasetQueries.xml
@@ -14,6 +14,7 @@
           <![CDATA[
             select dataset_presenter_id as dataset_id
             from apidbTuning.DatasetPresenter
+            where category != 'Link outs'
           ]]>
        </sql>
     </sqlQuery>

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -12,7 +12,7 @@ DatasetRecordClasses.DatasetRecordClass.Publications	topic_0219_synonym	Curation
 DatasetRecordClasses.DatasetRecordClass.HyperLinks	http://edamontology.org/topic_3345	Data identity and mapping	DatasetRecordClasses.DatasetRecordClass	table	HyperLinks						results	record	download
 DatasetRecordClasses.DatasetRecordClass.GenomeHistory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	GenomeHistory						results	record	download
 DatasetRecordClasses.DatasetRecordClass.References	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	References						results	record	download
-DatasetRecordClasses.DatasetRecordClass.Version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Version						results	record	download
+DatasetRecordClasses.DatasetRecordClass.Version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Version						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.AccessRequestStats	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	AccessRequestStats					23	results	record	download
 DatasetRecordClasses.DatasetRecordClass.AccessRequest	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	AccessRequest					24	results	record	download
 DatasetRecordClasses.DatasetRecordClass.DatasetGeneTable	http://edamontology.org/topic_3345	Data identity and mapping	DatasetRecordClasses.DatasetRecordClass	table	DatasetGeneTable								download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -18,7 +18,7 @@ DatasetRecordClasses.DatasetRecordClass.AccessRequest	topic_0219_synonym	Curatio
 DatasetRecordClasses.DatasetRecordClass.DatasetGeneTable	http://edamontology.org/topic_3345	Data identity and mapping	DatasetRecordClasses.DatasetRecordClass	table	DatasetGeneTable								download
 DatasetRecordClasses.DatasetRecordClass.primary_key	topic_0219_synonym		DatasetRecordClasses.DatasetRecordClass	attribute	primary_key					1	results		download
 DatasetRecordClasses.DatasetRecordClass.bulk_download_url	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	bulk_download_url						results	record-internal	download
-DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_prefix						results	record	
+DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_prefix						results	record-internal	
 DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_download								download
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download
 DatasetRecordClasses.DatasetRecordClass.category	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	category						results	record	


### PR DESCRIPTION
In order to simplify the dataset record pages and dataset search, this PR makes the following changes:

1. Unifies the strategy for providing attribution when category="Link Outs"
2. Hides the second instance of duplicated attributes on dataset record pages.