### PR TITLE
Organism genome record cleanup

### DIFF
--- a/Model/lib/wdk/model/questions/datasetQuestions.xml
+++ b/Model/lib/wdk/model/questions/datasetQuestions.xml
@@ -160,6 +160,19 @@
       </description>
     </question>
 
+    <question name="DatasetsByCategory"
+      displayName="Data Sets by Category"
+      shortDisplayName="Category"
+      fullAnswer="true"
+      queryRef="DatasetIds.ByCategory"
+      recordClassRef="DatasetRecordClasses.DatasetRecordClass"
+      noSummaryOnSingleRecord="true">
+      <description>
+         Find data sets that are associated with a particular category
+      </description>
+    </question>
+
+
     <question name="DatasetsByUserId"
       displayName="Data Sets study_access level based on user_id"
       shortDisplayName="StudyAccess"

--- a/Model/lib/wdk/model/questions/queries/datasetQueries.xml
+++ b/Model/lib/wdk/model/questions/queries/datasetQueries.xml
@@ -227,6 +227,21 @@ select distinct ref.dataset_presenter_id as dataset_id, ref.target_name, ref.rec
        </sql>
     </sqlQuery>
 
+    <sqlQuery name="ByCategory">
+
+        <paramRef ref="datasetParams.dataset_category"/>
+        <column name="dataset_id"/>
+
+        <sql>
+          <![CDATA[
+                   select DISTINCT dsp.dataset_presenter_id as dataset_id
+                   from apidbtuning.datasetpresenter dsp
+                   where nvl(dsp.display_category, dsp.category) = $$dataset_category$$
+          ]]>
+       </sql>
+    </sqlQuery>
+
+
     <sqlQuery name="ByUserId" includeProjects="ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
         <testParamValues>
           <paramValue name="user_id">48</paramValue>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -227,6 +227,9 @@ while in protected and private studies there will be human intervention in the d
                           help= "A request from the data provider stipulating the proper use of unpublished data. "  />
        </attributeQueryRef>
 
+      <attributeQueryRef ref="DatasetAttributes.genecounts">
+         <columnAttribute name="gene_count" displayName="Genes" help="Total gene count" align="right" />
+      </attributeQueryRef>
 
        <attributeQueryRef ref="DatasetAttributes.Contacts">
          <columnAttribute name="contact" displayName="Contact" 
@@ -709,6 +712,25 @@ OR if the linkName and or URL require access to other attributes....also how to 
       <testRowCountSql>
         select count(*) from ApidbTuning.DatasetPresenter
       </testRowCountSql>
+
+      <sqlQuery name="genecounts" isCacheable="false">
+        <column name="dataset_id"/>
+        <column name="gene_count"/>
+        <sql>
+          select dsp.dataset_presenter_id as dataset_id
+            , count(*) as gene_count
+          from apidbtuning.organismattributes oa
+            , apidbtuning.geneattributes ga
+            , apidbtuning.datasetpresenter dsp
+            , apidbtuning.datasetnametaxon dnt
+          where oa.component_taxon_id = ga.taxon_id
+          and oa.project_id = ga.project_id
+          and oa.component_taxon_id = dnt.taxon_id
+          and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+          and dsp.type = 'genome'
+          group by oa.project_id, dsp.dataset_presenter_id
+        </sql>
+      </sqlQuery>
 
       <sqlQuery name="ExpTechnique" isCacheable="false">
          <column name="exp_technique"/>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -567,6 +567,7 @@ OR if the linkName and or URL require access to other attributes....also how to 
             <columnAttribute name="build" displayName="VEuPathDB Build"/>
             <columnAttribute name="release_date" displayName="Release Date"/>
             <columnAttribute name="release_number" displayName="Release"/>
+            <columnAttribute name="version" displayName="Data Set Version"/>
             <columnAttribute name="note" displayName="Note"/>
         </table>
 
@@ -1439,19 +1440,26 @@ from apidbtuning.datasetnametaxon dsnt
             <column name="release_date"/>
             <column name="project"/>
             <column name="release_number"/>
+            <column name="version"/>
             <column name="note"/>
             <sql>
             <![CDATA[
              select dh.dataset_presenter_id as dataset_id
-               , bd.build_number as build
-               , to_char(bd.release_date, 'yyyy-mm-dd') as release_date
-               , bd.project
-               , bd.release_number
-               , dh.functional_annotation_version,dh.note
-             from ApidbTuning.DatasetHistory dh, ApidbTuning.EupathBuildDates bd
-             where dh.build_number = bd.build_number
-               and bd.project = '@PROJECT_ID@'
-             order by bd.build_number
+		   , bd.build_number as build
+		   , to_char(bd.release_date, 'yyyy-mm-dd') as release_date
+		   , bd.project
+		   , bd.release_number
+		   , ds.version
+		   , dh.note
+		 from ApidbTuning.DatasetHistory dh
+		   , ApidbTuning.EupathBuildDates bd
+		   , apidb.datasource ds
+		   , ApidbTuning.DatasetPresenter dsp
+		 where dh.build_number = bd.build_number
+		   and bd.project = '@PROJECT_ID@'
+		   and ds.name (+) = dsp.name
+		   and dh.dataset_presenter_id = dsp.dataset_presenter_id
+		 order by bd.build_number
             ]]>
             </sql>
       </sqlQuery>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -685,13 +685,13 @@ OR if the linkName and or URL require access to other attributes....also how to 
                displayName="Explore other Categories of Data Associated with this Genome"
                queryRef="DatasetTables.GenomeAssociatedData">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
-            <columnAttribute name="category"  displayName="Category" internal="true"/>
+            <columnAttribute name="category"  displayName="Category"/>
+            <columnAttribute name="dataset_count" displayName="Dataset count" internal="true"/>
             <linkAttribute name="hyper_link" inReportMaker="false" internal="false"
-                           displayName="Category">
-
+                           displayName="Dataset count">
                  <displayText>
                     <![CDATA[
-                    $$category$$
+                    $$dataset_count$$
                     ]]>
                  </displayText>
                  <url>
@@ -700,8 +700,6 @@ OR if the linkName and or URL require access to other attributes....also how to 
                     ]]>
                  </url>
             </linkAttribute>
-            
-            <columnAttribute name="dataset_count" displayName="Dataset count"/>
         </table>
 
         

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -2016,7 +2016,7 @@ and graph_descrip.dataset = dnt.name) g
               and oa.component_taxon_id = dnt.taxon_id
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
-              and o_dsp.category != 'Annotation, curation and identifiers'
+              and o_dsp.category != 'Genomics'
               group by dsp.dataset_presenter_id, o_dsp.category
             order by count(*) desc
             </sql>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -1776,7 +1776,6 @@ and graph_descrip.dataset = dnt.name) g
             <column name="transcript_count"/>
 
             <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
-            <![CDATA[
               select dsp.dataset_presenter_id as dataset_id
                 , ta.gene_type
                 , ta.transcript_type
@@ -1790,10 +1789,8 @@ and graph_descrip.dataset = dnt.name) g
               and oa.component_taxon_id = dnt.taxon_id
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
-              --and dsp.dataset_presenter_id = 'DS_b08fa4ba88'
               group by oa.project_id, dsp.dataset_presenter_id, ta.gene_type, ta.transcript_type
-              order by count(*) desc;
-            ]]>
+              order by count(*) desc
             </sql>
 
       </sqlQuery>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -1700,7 +1700,8 @@ ORDER by start_date desc
 		        , '' as target_name
 		        , 'genomicsInternal' as link_type
 	        from apidbtuning.GenomicsInternalHyperlink
-	        union
+	        where url not like '%app/record/organism/%'
+                union
 	        select * from projectQuestionLinks
 
 	    ]]>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -1140,8 +1140,8 @@ ON mm.dataset_id = counts.dataset_presenter_id
          <sql excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
             <![CDATA[
             select dsp.dataset_presenter_id as dataset_id
-                 , case when oa.is_annotated_genome = 1 then 'Genome Sequence and Annotation for <i>' || oa.species || '</i> ' || oa.strain
-                        when oa.is_annotated_genome = 0 then 'Genome Sequence for <i>' || oa.species || '</i> ' || oa.strain
+                 , case when oa.is_annotated_genome = 1 then '<i>' || oa.species || '</i> ' || oa.strain || ' Genome Sequence and Annotation'
+                        when oa.is_annotated_genome = 0 then '<i>' || oa.species || '</i> ' || oa.strain || ' Genome Sequence'   
                         else dsp.display_name
                    end as display_name
             from apidbtuning.datasetpresenter dsp

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -723,8 +723,22 @@ OR if the linkName and or URL require access to other attributes....also how to 
                displayName="External Databases Associated to Genome Annotation"
                queryRef="DatasetTables.ExternalDatabases">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
-            <columnAttribute name="name"  displayName="Name"/>
-            <columnAttribute name="id_url"  displayName="URL"/>
+            <columnAttribute name="name"  internal="true"/>
+            <columnAttribute name="id_url"  internal="true"/>
+            <linkAttribute name="external_link" inReportMaker="false" internal="false"
+                           displayName="Name">
+
+                 <displayText>
+                    <![CDATA[
+                    $$name$$
+                    ]]>
+                 </displayText>
+                 <url>
+                    <![CDATA[
+                          $$id_url$$
+                    ]]>
+                 </url>
+            </linkAttribute>
         </table>
 
 
@@ -2100,82 +2114,91 @@ and graph_descrip.dataset = dnt.name) g
             
 
             <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
-              select dsp.dataset_presenter_id as dataset_id
-              , ext.dataset as name, id_url
-              from apidbtuning.datasetnametaxon dnt, apidbtuning.datasetpresenter dsp,
+		   <![CDATA[
+                    with full_urls_table as (
+			      select dsp.dataset_presenter_id as dataset_id
+			      , ext.dataset as name, id_url
+			      from apidbtuning.datasetnametaxon dnt, apidbtuning.datasetpresenter dsp,
 
-              (select distinct * from (
-              SELECT 
-            edd.dataset_presenter_display_name AS dataset
-            ,ga.taxon_id
-            , edr.id_url
-              FROM
-            sres.dbref db
-              , DOTS.dbrefnafeature dbna
-              , apidbtuning.ExternalDbDatasetPresenter edd
-              , sres.externaldatabaserelease edr
-              , ApidbTuning.geneAttributes ga
-              WHERE
-            db.external_database_release_id = edd.external_database_release_id
-            AND edr.external_database_release_id = edd.external_database_release_id
-            AND dbna.db_ref_id = db.db_ref_id
-            AND ga.na_feature_id = dbna.na_feature_id
-            UNION
-              SELECT 
-            edd.dataset_presenter_display_name AS dataset
-            , ta.taxon_id
-            , edr.id_url
-              FROM
-            sres.dbref db
-              , DOTS.dbrefnafeature dbna
-              , apidbtuning.ExternalDbDatasetPresenter edd
-              , sres.externaldatabaserelease edr
-              , ApidbTuning.transcriptAttributes ta
-              WHERE
-            db.external_database_release_id = edd.external_database_release_id
-            AND edr.external_database_release_id = edd.external_database_release_id
-            AND dbna.db_ref_id = db.db_ref_id
-            AND ta.na_feature_id = dbna.na_feature_id
-            UNION
-              SELECT d.name as dataset
-              , ga.taxon_id
-            , eru.id_url
-              FROM
-            sres.dbref dbr
-              , DOTS.dbrefnafeature dbrf
-              , sres.externaldatabaserelease r
-              , sres.externaldatabase d
-              , ApidbTuning.geneAttributes ga
-              , APIDB.EXTERNALRESOURCEURL eru
-              WHERE dbr.external_database_release_id = r.external_database_release_id
-              and r.external_database_id = d.external_database_id
-              and dbr.db_ref_id = dbrf.db_ref_id
-              and dbrf.na_feature_id = ga.na_feature_id
-              and upper(d.name) = eru.database_name
-              UNION
-              SELECT d.name as dataset
-              , ta.taxon_id
-            , eru.id_url
-              FROM
-            sres.dbref dbr
-              , DOTS.dbrefaafeature dbrf
-              , Dots.aafeature aaf
-              , sres.externaldatabaserelease r
-              , sres.externaldatabase d
-              , ApidbTuning.transcriptAttributes ta
-              , APIDB.EXTERNALRESOURCEURL eru
-              WHERE dbr.external_database_release_id = r.external_database_release_id
-              and r.external_database_id = d.external_database_id
-              and dbr.db_ref_id = dbrf.db_ref_id
-              and dbrf.aa_feature_id = aaf.aa_feature_id
-              and aaf.aa_sequence_id = ta.aa_sequence_id
-              and upper(d.name) = eru.database_name
-              )
-              ) ext
-              where ext.taxon_id = dnt.taxon_id
-              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
-              and dsp.type = 'genome'
-              order by ext.dataset
+			      (select distinct * from (
+			      SELECT 
+			    edd.dataset_presenter_display_name AS dataset
+			    ,ga.taxon_id
+			    , edr.id_url
+			      FROM
+			    sres.dbref db
+			      , DOTS.dbrefnafeature dbna
+			      , apidbtuning.ExternalDbDatasetPresenter edd
+			      , sres.externaldatabaserelease edr
+			      , ApidbTuning.geneAttributes ga
+			      WHERE
+			    db.external_database_release_id = edd.external_database_release_id
+			    AND edr.external_database_release_id = edd.external_database_release_id
+			    AND dbna.db_ref_id = db.db_ref_id
+			    AND ga.na_feature_id = dbna.na_feature_id
+			    UNION
+			      SELECT 
+			    edd.dataset_presenter_display_name AS dataset
+			    , ta.taxon_id
+			    , edr.id_url
+			      FROM
+			    sres.dbref db
+			      , DOTS.dbrefnafeature dbna
+			      , apidbtuning.ExternalDbDatasetPresenter edd
+			      , sres.externaldatabaserelease edr
+			      , ApidbTuning.transcriptAttributes ta
+			      WHERE
+			    db.external_database_release_id = edd.external_database_release_id
+			    AND edr.external_database_release_id = edd.external_database_release_id
+			    AND dbna.db_ref_id = db.db_ref_id
+			    AND ta.na_feature_id = dbna.na_feature_id
+			    UNION
+			      SELECT d.name as dataset
+			      , ga.taxon_id
+			    , eru.id_url
+			      FROM
+			    sres.dbref dbr
+			      , DOTS.dbrefnafeature dbrf
+			      , sres.externaldatabaserelease r
+			      , sres.externaldatabase d
+			      , ApidbTuning.geneAttributes ga
+			      , APIDB.EXTERNALRESOURCEURL eru
+			      WHERE dbr.external_database_release_id = r.external_database_release_id
+			      and r.external_database_id = d.external_database_id
+			      and dbr.db_ref_id = dbrf.db_ref_id
+			      and dbrf.na_feature_id = ga.na_feature_id
+			      and upper(d.name) = eru.database_name
+			      UNION
+			      SELECT d.name as dataset
+			      , ta.taxon_id
+			    , eru.id_url
+			      FROM
+			    sres.dbref dbr
+			      , DOTS.dbrefaafeature dbrf
+			      , Dots.aafeature aaf
+			      , sres.externaldatabaserelease r
+			      , sres.externaldatabase d
+			      , ApidbTuning.transcriptAttributes ta
+			      , APIDB.EXTERNALRESOURCEURL eru
+			      WHERE dbr.external_database_release_id = r.external_database_release_id
+			      and r.external_database_id = d.external_database_id
+			      and dbr.db_ref_id = dbrf.db_ref_id
+			      and dbrf.aa_feature_id = aaf.aa_feature_id
+			      and aaf.aa_sequence_id = ta.aa_sequence_id
+			      and upper(d.name) = eru.database_name
+			      )
+			      ) ext
+			      where ext.taxon_id = dnt.taxon_id
+			      and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+			      and dsp.type = 'genome'
+			      order by ext.dataset
+			      )
+		select dataset_id
+		  , name
+		  , nvl(decode(substr(id_url,0, instr(id_url, '/', 1, 3)),
+                      'http://version_10.string-db.org/', 'http://string-db.org/'), substr(id_url,0, instr(id_url, '/', 1, 3))) as id_url
+		from full_urls_table
+                  ]]>
             </sql>
 
       </sqlQuery>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -620,6 +620,18 @@ OR if the linkName and or URL require access to other attributes....also how to 
 
         </table>
 
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <!-- Transcript type counts -->
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <table name="TranscriptTypeCounts" 
+               excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
+               displayName="Gene Types"
+               queryRef="DatasetTables.TranscriptTypeCounts">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="gene_type"  displayName="Gene type"/>
+            <columnAttribute name="transcript_type" displayName="Transcript type"/>
+            <columnAttribute name="transcript_count" displayName="Transcript count"/>
+        </table>
 
 
       </recordClass>
@@ -1755,6 +1767,35 @@ where p.dataset = graph_descrip.dataset
 and graph_descrip.dataset = dnt.name) g
              ]]>
             </sql>
+      </sqlQuery>
+
+      <sqlQuery name="TranscriptTypeCounts">
+            <column name="dataset_id"/>
+            <column name="gene_type"/>
+            <column name="transcript_type"/>
+            <column name="transcript_count"/>
+
+            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <![CDATA[
+              select dsp.dataset_presenter_id as dataset_id
+                , ta.gene_type
+                , ta.transcript_type
+                , count(*) as transcript_count
+              from apidbtuning.organismattributes oa
+                , apidbtuning.transcriptattributes ta
+                , apidbtuning.datasetpresenter dsp
+                , apidbtuning.datasetnametaxon dnt
+              where oa.component_taxon_id = ta.taxon_id
+              and oa.project_id = ta.project_id
+              and oa.component_taxon_id = dnt.taxon_id
+              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+              and dsp.type = 'genome'
+              --and dsp.dataset_presenter_id = 'DS_b08fa4ba88'
+              group by oa.project_id, dsp.dataset_presenter_id, ta.gene_type, ta.transcript_type
+              order by count(*) desc;
+            ]]>
+            </sql>
+
       </sqlQuery>
 
 <!--

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -646,8 +646,26 @@ OR if the linkName and or URL require access to other attributes....also how to 
             <columnAttribute name="feature_count" displayName="Feature count"/>
         </table>
 
+
+
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <!-- Other data associated with genomes -->
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <table name="GenomeAssociatedData" 
+               excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
+               displayName="Additional data associated with this genome"
+               queryRef="DatasetTables.GenomeAssociatedData">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="category"  displayName="Category"/>
+            <columnAttribute name="dataset_count" displayName="Dataset count"/>
+        </table>
+
+
+
+
       </recordClass>
     </recordClassSet>
+
 
 
 
@@ -1831,6 +1849,32 @@ and graph_descrip.dataset = dnt.name) g
               and dsp.type = 'genome'
               group by dsp.dataset_presenter_id, sa.sequence_type, fl.feature_type
               order by count(*) desc
+            </sql>
+
+      </sqlQuery>
+
+
+       <sqlQuery name="GenomeAssociatedData">
+            <column name="dataset_id"/>
+            <column name="category"/>
+            <column name="dataset_count"/>
+
+            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+              select dsp.dataset_presenter_id as dataset_id
+                , o_dsp.category
+                , count(*) as dataset_count
+              from apidbtuning.organismattributes oa
+                , apidbtuning.datasetpresenter o_dsp
+                , apidbtuning.datasetnametaxon o_dnt
+                , apidbtuning.datasetnametaxon dnt
+                , apidbtuning.datasetpresenter dsp
+              where oa.component_taxon_id = o_dnt.taxon_id
+              and o_dnt.dataset_presenter_id = o_dsp.dataset_presenter_id
+              and oa.component_taxon_id = dnt.taxon_id
+              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+              and dsp.type = 'genome'
+              group by dsp.dataset_presenter_id, o_dsp.category
+            order by count(*) desc
             </sql>
 
       </sqlQuery>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -633,6 +633,18 @@ OR if the linkName and or URL require access to other attributes....also how to 
             <columnAttribute name="transcript_count" displayName="Transcript count"/>
         </table>
 
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <!-- Sequence type counts -->
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <table name="SequenceTypeCounts" 
+               excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
+               displayName="Sequence Types"
+               queryRef="DatasetTables.SequenceTypeCounts">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="sequence_type"  displayName="Sequence type"/>
+            <columnAttribute name="feature_type" displayName="Feature type"/>
+            <columnAttribute name="feature_count" displayName="Feature count"/>
+        </table>
 
       </recordClass>
     </recordClassSet>
@@ -1790,6 +1802,34 @@ and graph_descrip.dataset = dnt.name) g
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
               group by oa.project_id, dsp.dataset_presenter_id, ta.gene_type, ta.transcript_type
+              order by count(*) desc
+            </sql>
+
+      </sqlQuery>
+
+      <sqlQuery name="SequenceTypeCounts">
+            <column name="dataset_id"/>
+            <column name="sequence_type"/>
+            <column name="feature_type"/>
+            <column name="feature_count"/>
+
+            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+              select dsp.dataset_presenter_id
+                , sa.sequence_type
+                , fl.feature_type
+                , count(*) as feature_count
+              from apidbtuning.organismattributes oa
+                , ApidbTuning.GenomicSeqAttributes sa
+                , apidb.featurelocation fl
+                , apidbtuning.datasetpresenter dsp
+                , apidbtuning.datasetnametaxon dnt
+              where oa.component_taxon_id = sa.taxon_id
+              and oa.project_id = sa.project_id
+              and sa.na_sequence_id = fl.na_sequence_id
+              and oa.component_taxon_id = dnt.taxon_id
+              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+              and dsp.type = 'genome'
+              group by dsp.dataset_presenter_id, sa.sequence_type, fl.feature_type
               order by count(*) desc
             </sql>
 

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -134,6 +134,12 @@
          <columnAttribute name="display_name" internal="true" displayName="Dataset Name" removable="false"/>
        </attributeQueryRef>
 
+        <attributeQueryRef ref="DatasetAttributes.GenomicsDatasetAttributes">
+         <columnAttribute name="megabase_pairs" displayName="Megabase Pairs" removable="false"/>
+         <columnAttribute name="genecount" displayName="Genes" help="Total gene count" align="right" />
+       </attributeQueryRef>
+
+
        <attributeQueryRef ref="DatasetAttributes.DatasetDigest" includeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
          <columnAttribute name="dataset_sha1_digest" internal="true"/>
          <columnAttribute name="dataset_display_name" internal="true"/>
@@ -246,7 +252,7 @@ while in protected and private studies there will be human intervention in the d
        </attributeQueryRef>
 
       <!--   <attributesList summary="organism_prefix,version,eupath_release,build_number_introduced,newcategory,pmids,summary,contact" -->
-        <attributesList summary="organism_prefix,version,eupath_release,newcategory,pmids,summary,contact"
+        <attributesList summary="organism_prefix,version,eupath_release,newcategory,pmids,summary,contact,megabase_pairs"
                         excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR,EuPathDB"/>
 
         <attributesList summary="organism_prefix,project_id,eupath_release,newcategory,pmids,summary,contact"
@@ -1149,6 +1155,23 @@ ON mm.dataset_id = counts.dataset_presenter_id
                      on dsp.name = oa.public_abbrev || '_primary_genome_RSRC'
             ]]>
          </sql>
+      </sqlQuery>
+
+      <sqlQuery name="GenomicsDatasetAttributes" isCacheable="false" excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
+        <column name="dataset_id"/>
+        <column name="megabase_pairs"/>
+        <column name="genecount"/>
+
+        <sql>
+          <![CDATA[
+          select dsp.dataset_presenter_id as dataset_id
+              , oa.megabps as megabase_pairs
+              , nullif(oa.genecount, 0) as genecount
+          from apidbtuning.datasetpresenter dsp
+              left join apidbtuning.organismattributes oa
+                  on dsp.name = oa.public_abbrev || '_primary_genome_RSRC'
+          ]]>
+        </sql>
       </sqlQuery>
 
       <sqlQuery name="All"  isCacheable="false">

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -674,7 +674,7 @@ OR if the linkName and or URL require access to other attributes....also how to 
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <table name="GenomeAssociatedData" 
                excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
-               displayName="Additional data associated with this genome"
+               displayName="Additional kinds of  data associated with this genome"
                queryRef="DatasetTables.GenomeAssociatedData">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
             <columnAttribute name="category"  displayName="Category"/>
@@ -1949,6 +1949,7 @@ and graph_descrip.dataset = dnt.name) g
               and oa.component_taxon_id = dnt.taxon_id
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
+              and o_dsp.category != 'Annotation, curation and identifiers'
               group by dsp.dataset_presenter_id, o_dsp.category
             order by count(*) desc
             </sql>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -546,6 +546,16 @@ OR if the linkName and or URL require access to other attributes....also how to 
             <columnAttribute name="note" displayName="Note"/>
         </table>
 
+        <table name="DatasetHistory" excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR"
+               displayName="Data Set Release History"
+               queryRef="DatasetTables.DatasetHistory">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="build" displayName="VEuPathDB Build"/>
+            <columnAttribute name="release_date" displayName="Release Date"/>
+            <columnAttribute name="release_number" displayName="Release"/>
+            <columnAttribute name="note" displayName="Note"/>
+        </table>
+
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <!-- References -->
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
@@ -1317,6 +1327,29 @@ from apidbtuning.datasetnametaxon dsnt
                     bd.project, bd.release_number, dh.genome_source,
 	                  dh.genome_version, dh.annotation_source, dh.annotation_version,
                     dh.functional_annotation_source, dh.functional_annotation_version,dh.note
+             from ApidbTuning.DatasetHistory dh, ApidbTuning.EupathBuildDates bd
+             where dh.build_number = bd.build_number
+               and bd.project = '@PROJECT_ID@'
+             order by bd.build_number
+            ]]>
+            </sql>
+      </sqlQuery>
+
+      <sqlQuery name="DatasetHistory"  isCacheable='false'>
+            <column name="dataset_id"/>
+            <column name="build"/>
+            <column name="release_date"/>
+            <column name="project"/>
+            <column name="release_number"/>
+            <column name="note"/>
+            <sql>
+            <![CDATA[
+             select dh.dataset_presenter_id as dataset_id
+               , bd.build_number as build
+               , to_char(bd.release_date, 'yyyy-mm-dd') as release_date
+               , bd.project
+               , bd.release_number
+               , dh.functional_annotation_version,dh.note
              from ApidbTuning.DatasetHistory dh, ApidbTuning.EupathBuildDates bd
              where dh.build_number = bd.build_number
                and bd.project = '@PROJECT_ID@'

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -139,6 +139,11 @@
          <columnAttribute name="genecount" displayName="Genes" help="Total gene count" align="right" />
        </attributeQueryRef>
 
+        <attributeQueryRef ref="DatasetAttributes.LatestVersion">
+         <columnAttribute name="genome_version" displayName="Genome Version" removable="false"/>
+         <columnAttribute name="annotation_version" displayName="Annotation Version" removable="false"/>
+         <columnAttribute name="functional_annotation_version" displayName="Functional Annotation Version" removable="false"/>
+       </attributeQueryRef>
 
        <attributeQueryRef ref="DatasetAttributes.DatasetDigest" includeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
          <columnAttribute name="dataset_sha1_digest" internal="true"/>
@@ -252,7 +257,7 @@ while in protected and private studies there will be human intervention in the d
        </attributeQueryRef>
 
       <!--   <attributesList summary="organism_prefix,version,eupath_release,build_number_introduced,newcategory,pmids,summary,contact" -->
-        <attributesList summary="organism_prefix,version,eupath_release,newcategory,pmids,summary,contact,megabase_pairs"
+        <attributesList summary="organism_prefix,version,eupath_release,newcategory,pmids,summary,contact,genome_version,annotation_version,functional_annotation_version,megabase_pairs"
                         excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR,EuPathDB"/>
 
         <attributesList summary="organism_prefix,project_id,eupath_release,newcategory,pmids,summary,contact"
@@ -1174,6 +1179,40 @@ ON mm.dataset_id = counts.dataset_presenter_id
           ]]>
         </sql>
       </sqlQuery>
+
+      <sqlQuery name="LatestVersion" isCacheable="false" excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
+        <column name="dataset_id"/>
+        <column name="genome_version"/>
+        <column name="annotation_version"/>
+        <column name="functional_annotation_version"/>
+
+        <sql>
+          <![CDATA[
+		with all_versions as (
+		     select dh.dataset_presenter_id as dataset_id
+		       , bd.project
+		       , bd.release_number
+		       , dh.genome_version
+		       , dh.annotation_version
+		       , dh.functional_annotation_version
+		       , row_number() OVER(PARTITION BY dh.dataset_presenter_id ORDER BY bd.release_number desc) rn
+		     from ApidbTuning.DatasetHistory dh
+		       , ApidbTuning.EupathBuildDates bd
+		     where dh.build_number = bd.build_number
+		       and bd.project = '@PROJECT_ID@'
+		     order by dh.dataset_presenter_id
+		       , bd.release_number desc
+		)
+		select dataset_id
+		  , genome_version
+		  , annotation_version
+		  , functional_annotation_version
+		from all_versions
+		where rn = 1
+          ]]>
+        </sql>
+      </sqlQuery>
+
 
       <sqlQuery name="All"  isCacheable="false">
          <column name="dataset_id"/>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -635,12 +635,24 @@ OR if the linkName and or URL require access to other attributes....also how to 
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <table name="TranscriptTypeCounts" 
                excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
-               displayName="Gene Types"
+               displayName="Transcript Types"
                queryRef="DatasetTables.TranscriptTypeCounts">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
             <columnAttribute name="gene_type"  displayName="Gene type"/>
             <columnAttribute name="transcript_type" displayName="Transcript type"/>
             <columnAttribute name="transcript_count" displayName="Transcript count"/>
+        </table>
+
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <!-- Gene type counts -->
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <table name="GeneTypeCounts" 
+               excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
+               displayName="Gene Types"
+               queryRef="DatasetTables.GeneTypeCounts">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="gene_type"  displayName="Gene type"/>
+            <columnAttribute name="gene_count" displayName="Gene count"/>
         </table>
 
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
@@ -1862,6 +1874,30 @@ and graph_descrip.dataset = dnt.name) g
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
               group by oa.project_id, dsp.dataset_presenter_id, ta.gene_type, ta.transcript_type
+              order by count(*) desc
+            </sql>
+
+      </sqlQuery>
+
+      <sqlQuery name="GeneTypeCounts">
+            <column name="dataset_id"/>
+            <column name="gene_type"/>
+            <column name="gene_count"/>
+
+            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+              select dsp.dataset_presenter_id as dataset_id
+                , ga.gene_type
+                , count(*) as gene_count
+              from apidbtuning.organismattributes oa
+                , apidbtuning.geneattributes ga
+                , apidbtuning.datasetpresenter dsp
+                , apidbtuning.datasetnametaxon dnt
+              where oa.component_taxon_id = ga.taxon_id
+              and oa.project_id = ga.project_id
+              and oa.component_taxon_id = dnt.taxon_id
+              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+              and dsp.type = 'genome'
+              group by oa.project_id, dsp.dataset_presenter_id, ga.gene_type
               order by count(*) desc
             </sql>
 

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -1837,6 +1837,7 @@ ORDER by start_date desc
 	        where url not like '%app/record/organism/%'
                 union
 	        select * from projectQuestionLinks
+                order by text
 
 	    ]]>
             </sql>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -129,6 +129,11 @@
        </attributeQueryRef>
 -->
 
+
+       <attributeQueryRef ref="DatasetAttributes.DatasetDisplayName">
+         <columnAttribute name="display_name" internal="true" displayName="Dataset Name" removable="false"/>
+       </attributeQueryRef>
+
        <attributeQueryRef ref="DatasetAttributes.DatasetDigest" includeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
          <columnAttribute name="dataset_sha1_digest" internal="true"/>
          <columnAttribute name="dataset_display_name" internal="true"/>
@@ -201,7 +206,7 @@ while in protected and private studies there will be human intervention in the d
        <attributeQueryRef ref="DatasetAttributes.All">
          <columnAttribute name="dataset_name" internal="true" displayName="Data Set Name" help="Name of the dataset."/>
          <columnAttribute name="dataset_name_pattern" internal="true" inReportMaker="false"/>
-         <columnAttribute name="display_name" internal="true" displayName="Dataset Name" removable="false"/>
+<!--         <columnAttribute name="display_name" internal="true" displayName="Dataset Name" removable="false"/> -->
          <columnAttribute name="short_display_name" internal="true"/>
          <columnAttribute name="version" displayName="Data Set Version"  internal="true" includeProjects="MicrobiomeDB,EuPathDB"/>
           <columnAttribute name="version" displayName="Data Set Version" help="The data set provider's version number or publication date, from the site the data was acquired. In the rare case neither is available, the download date." excludeProjects="MicrobiomeDB,ClinEpiDB,AllClinEpiDB,EuPathDB"/>
@@ -496,7 +501,7 @@ OR if the linkName and or URL require access to other attributes....also how to 
         <!-- External Links -->
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <table name="HyperLinks"
-               displayName="External resources"
+               displayName="External Resources"
                queryRef="DatasetTables.HyperLinks">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
             <columnAttribute name="text" internal="true"/>
@@ -677,10 +682,25 @@ OR if the linkName and or URL require access to other attributes....also how to 
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <table name="GenomeAssociatedData" 
                excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
-               displayName="Additional kinds of  data associated with this genome"
+               displayName="Explore other Categories of Data Associated with this Genome"
                queryRef="DatasetTables.GenomeAssociatedData">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
-            <columnAttribute name="category"  displayName="Category"/>
+            <columnAttribute name="category"  displayName="Category" internal="true"/>
+            <linkAttribute name="hyper_link" inReportMaker="false" internal="false"
+                           displayName="Category">
+
+                 <displayText>
+                    <![CDATA[
+                    $$category$$
+                    ]]>
+                 </displayText>
+                 <url>
+                    <![CDATA[
+                          @WEBAPP_BASE_URL@/search/dataset/DatasetsByCategory?param.dataset_category=$$category$$&autoRun=1
+                    ]]>
+                 </url>
+            </linkAttribute>
+            
             <columnAttribute name="dataset_count" displayName="Dataset count"/>
         </table>
 
@@ -690,10 +710,11 @@ OR if the linkName and or URL require access to other attributes....also how to 
         <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
         <table name="ExternalDatabases" 
                excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
-               displayName="Additional external databases"
+               displayName="External Databases Associated to Genome Annotation"
                queryRef="DatasetTables.ExternalDatabases">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
             <columnAttribute name="name"  displayName="Name"/>
+            <columnAttribute name="id_url"  displayName="URL"/>
         </table>
 
 
@@ -1108,13 +1129,35 @@ ON mm.dataset_id = counts.dataset_presenter_id
       </sqlQuery>
 
 
+      <sqlQuery name="DatasetDisplayName"  isCacheable="false">
+         <column name="dataset_id"/>
+         <column name="display_name" ignoreCase="true"/>
 
+         <sql includeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">>
+            <![CDATA[
+            select dsp.dataset_presenter_id as dataset_id, dsp.display_name from apidbtuning.datasetpresenter dsp
+            ]]>
+         </sql>
+
+         <sql excludeProjects="MicrobiomeDB,ClinEpiDB,Gates,AllClinEpiDB,ICEMR">
+            <![CDATA[
+            select dsp.dataset_presenter_id as dataset_id
+                 , case when oa.is_annotated_genome = 1 then 'Genome Sequence and Annotation for <i>' || oa.species || '</i> ' || oa.strain
+                        when oa.is_annotated_genome = 0 then 'Genome Sequence for <i>' || oa.species || '</i> ' || oa.strain
+                        else dsp.display_name
+                   end as display_name
+            from apidbtuning.datasetpresenter dsp
+                 left join apidbtuning.organismattributes oa
+                     on dsp.name = oa.public_abbrev || '_primary_genome_RSRC'
+            ]]>
+         </sql>
+      </sqlQuery>
 
       <sqlQuery name="All"  isCacheable="false">
          <column name="dataset_id"/>
          <column name="dataset_name"/>
          <column name="dataset_name_pattern"/>
-         <column name="display_name" ignoreCase="true"/>
+<!--         <column name="display_name" ignoreCase="true"/> -->
          <column name="short_display_name"/>
          <column name="description"/>
          <column name="version"/>
@@ -1131,7 +1174,8 @@ ON mm.dataset_id = counts.dataset_presenter_id
             <![CDATA[
             select dsp.dataset_presenter_id as dataset_id,
                    dsp.name as dataset_name, dsp.dataset_name_pattern,
-                   dsp.display_name, ds.version,
+                   --dsp.display_name, 
+                   ds.version,
                    dsp.short_display_name, dsp.description,
                    nvl(dsp.summary, dsp.description) as summary,
                    dsp.protocol, dsp.usage, 
@@ -1983,16 +2027,19 @@ and graph_descrip.dataset = dnt.name) g
       <sqlQuery name="ExternalDatabases">
             <column name="dataset_id"/>
             <column name="name"/>
+            <column name="id_url"/>
+            
 
             <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
-              , ext.dataset as name
+              , ext.dataset as name, id_url
               from apidbtuning.datasetnametaxon dnt, apidbtuning.datasetpresenter dsp,
 
               (select distinct * from (
               SELECT 
             edd.dataset_presenter_display_name AS dataset
             ,ga.taxon_id
+            , edr.id_url
               FROM
             sres.dbref db
               , DOTS.dbrefnafeature dbna
@@ -2008,6 +2055,7 @@ and graph_descrip.dataset = dnt.name) g
               SELECT 
             edd.dataset_presenter_display_name AS dataset
             , ta.taxon_id
+            , edr.id_url
               FROM
             sres.dbref db
               , DOTS.dbrefnafeature dbna
@@ -2022,6 +2070,7 @@ and graph_descrip.dataset = dnt.name) g
             UNION
               SELECT d.name as dataset
               , ga.taxon_id
+            , eru.id_url
               FROM
             sres.dbref dbr
               , DOTS.dbrefnafeature dbrf
@@ -2037,6 +2086,7 @@ and graph_descrip.dataset = dnt.name) g
               UNION
               SELECT d.name as dataset
               , ta.taxon_id
+            , eru.id_url
               FROM
             sres.dbref dbr
               , DOTS.dbrefaafeature dbrf

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -660,7 +660,17 @@ OR if the linkName and or URL require access to other attributes....also how to 
             <columnAttribute name="dataset_count" displayName="Dataset count"/>
         </table>
 
-
+        
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <!-- External Resources and Databases for genomes -->
+        <!--++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
+        <table name="ExternalDatabases" 
+               excludeProjects="EupathDB,MicrobiomeDB,ClinEpiDB,AllClinEpiDB"
+               displayName="Additional external databases"
+               queryRef="DatasetTables.ExternalDatabases">
+            <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
+            <columnAttribute name="name"  displayName="Name"/>
+        </table>
 
 
       </recordClass>
@@ -1832,7 +1842,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="feature_count"/>
 
             <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
-              select dsp.dataset_presenter_id
+              select dsp.dataset_presenter_id as dataset_id
                 , sa.sequence_type
                 , fl.feature_type
                 , count(*) as feature_count
@@ -1875,6 +1885,88 @@ and graph_descrip.dataset = dnt.name) g
               and dsp.type = 'genome'
               group by dsp.dataset_presenter_id, o_dsp.category
             order by count(*) desc
+            </sql>
+
+      </sqlQuery>
+
+
+      <sqlQuery name="ExternalDatabases">
+            <column name="dataset_id"/>
+            <column name="name"/>
+
+            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+              select dsp.dataset_presenter_id as dataset_id
+              , ext.dataset as name
+              from apidbtuning.datasetnametaxon dnt, apidbtuning.datasetpresenter dsp,
+
+              (select distinct * from (
+              SELECT 
+            edd.dataset_presenter_display_name AS dataset
+            ,ga.taxon_id
+              FROM
+            sres.dbref db
+              , DOTS.dbrefnafeature dbna
+              , apidbtuning.ExternalDbDatasetPresenter edd
+              , sres.externaldatabaserelease edr
+              , ApidbTuning.geneAttributes ga
+              WHERE
+            db.external_database_release_id = edd.external_database_release_id
+            AND edr.external_database_release_id = edd.external_database_release_id
+            AND dbna.db_ref_id = db.db_ref_id
+            AND ga.na_feature_id = dbna.na_feature_id
+            UNION
+              SELECT 
+            edd.dataset_presenter_display_name AS dataset
+            , ta.taxon_id
+              FROM
+            sres.dbref db
+              , DOTS.dbrefnafeature dbna
+              , apidbtuning.ExternalDbDatasetPresenter edd
+              , sres.externaldatabaserelease edr
+              , ApidbTuning.transcriptAttributes ta
+              WHERE
+            db.external_database_release_id = edd.external_database_release_id
+            AND edr.external_database_release_id = edd.external_database_release_id
+            AND dbna.db_ref_id = db.db_ref_id
+            AND ta.na_feature_id = dbna.na_feature_id
+            UNION
+              SELECT d.name as dataset
+              , ga.taxon_id
+              FROM
+            sres.dbref dbr
+              , DOTS.dbrefnafeature dbrf
+              , sres.externaldatabaserelease r
+              , sres.externaldatabase d
+              , ApidbTuning.geneAttributes ga
+              , APIDB.EXTERNALRESOURCEURL eru
+              WHERE dbr.external_database_release_id = r.external_database_release_id
+              and r.external_database_id = d.external_database_id
+              and dbr.db_ref_id = dbrf.db_ref_id
+              and dbrf.na_feature_id = ga.na_feature_id
+              and upper(d.name) = eru.database_name
+              UNION
+              SELECT d.name as dataset
+              , ta.taxon_id
+              FROM
+            sres.dbref dbr
+              , DOTS.dbrefaafeature dbrf
+              , Dots.aafeature aaf
+              , sres.externaldatabaserelease r
+              , sres.externaldatabase d
+              , ApidbTuning.transcriptAttributes ta
+              , APIDB.EXTERNALRESOURCEURL eru
+              WHERE dbr.external_database_release_id = r.external_database_release_id
+              and r.external_database_id = d.external_database_id
+              and dbr.db_ref_id = dbrf.db_ref_id
+              and dbrf.aa_feature_id = aaf.aa_feature_id
+              and aaf.aa_sequence_id = ta.aa_sequence_id
+              and upper(d.name) = eru.database_name
+              )
+              ) ext
+              where ext.taxon_id = dnt.taxon_id
+              and dnt.dataset_presenter_id = dsp.dataset_presenter_id
+              and dsp.type = 'genome'
+              order by ext.dataset
             </sql>
 
       </sqlQuery>

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -2009,7 +2009,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="transcript_type"/>
             <column name="transcript_count"/>
 
-            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <sql excludeProjects="MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
                 , ta.gene_type
                 , ta.transcript_type
@@ -2034,7 +2034,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="gene_type"/>
             <column name="gene_count"/>
 
-            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <sql excludeProjects="MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
                 , ga.gene_type
                 , count(*) as gene_count
@@ -2058,7 +2058,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="sequence_type"/>
             <column name="sequence_count"/>
 
-            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <sql excludeProjects="MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
                 , sa.sequence_type
                 , count(*) as sequence_count
@@ -2085,7 +2085,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="category"/>
             <column name="dataset_count"/>
 
-            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <sql excludeProjects="MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
                 , o_dsp.category
                 , count(*) as dataset_count
@@ -2113,7 +2113,7 @@ and graph_descrip.dataset = dnt.name) g
             <column name="id_url"/>
             
 
-            <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
+            <sql excludeProjects="MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
 		   <![CDATA[
                     with full_urls_table as (
 			      select dsp.dataset_presenter_id as dataset_id

--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -652,8 +652,7 @@ OR if the linkName and or URL require access to other attributes....also how to 
                queryRef="DatasetTables.SequenceTypeCounts">
             <columnAttribute name="dataset_id"  inReportMaker="false" internal="true"/>
             <columnAttribute name="sequence_type"  displayName="Sequence type"/>
-            <columnAttribute name="feature_type" displayName="Feature type"/>
-            <columnAttribute name="feature_count" displayName="Feature count"/>
+            <columnAttribute name="sequence_count" displayName="Sequence count"/>
         </table>
 
 
@@ -1871,14 +1870,12 @@ and graph_descrip.dataset = dnt.name) g
       <sqlQuery name="SequenceTypeCounts">
             <column name="dataset_id"/>
             <column name="sequence_type"/>
-            <column name="feature_type"/>
-            <column name="feature_count"/>
+            <column name="sequence_count"/>
 
             <sql excludeProjects="EuPathDB, MicrobiomeDB, ClinEpiDB, AllClinEpiDB">
               select dsp.dataset_presenter_id as dataset_id
                 , sa.sequence_type
-                , fl.feature_type
-                , count(*) as feature_count
+                , count(*) as sequence_count
               from apidbtuning.organismattributes oa
                 , ApidbTuning.GenomicSeqAttributes sa
                 , apidb.featurelocation fl
@@ -1890,7 +1887,7 @@ and graph_descrip.dataset = dnt.name) g
               and oa.component_taxon_id = dnt.taxon_id
               and dnt.dataset_presenter_id = dsp.dataset_presenter_id
               and dsp.type = 'genome'
-              group by dsp.dataset_presenter_id, sa.sequence_type, fl.feature_type
+              group by dsp.dataset_presenter_id, sa.sequence_type
               order by count(*) desc
             </sql>
 

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -16,6 +16,7 @@ DatasetRecordClasses.DatasetRecordClass.Isolates	topic_0219_synonym	Curation and
 DatasetRecordClasses.DatasetRecordClass.Publications	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Publications					19	results	record	download
 DatasetRecordClasses.DatasetRecordClass.HyperLinks	http://edamontology.org/topic_3345	Data identity and mapping	DatasetRecordClasses.DatasetRecordClass	table	HyperLinks						results	record	download
 DatasetRecordClasses.DatasetRecordClass.GenomeHistory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	GenomeHistory						results	record	download
+DatasetRecordClasses.DatasetRecordClass.DatasetHistory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DatasetHistory						results	record	download
 DatasetRecordClasses.DatasetRecordClass.References	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	References						results	record	download
 DatasetRecordClasses.DatasetRecordClass.Version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Version						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.AccessRequestStats	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	AccessRequestStats					23	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -6,6 +6,7 @@ DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.Data
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
 DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
 DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.GeneTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	GeneTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
 DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -1,14 +1,14 @@
  			recordClassName	targetType	name	displayName	shortDisplayName	description	geneOrTranscript	displayOrder	scope	scope	scope
 			eupath/eupath.owl#recordClassName	eupath/eupath.owl#targetType	eupath/eupath.owl#name	EUPATH_0000052	eupath/eupath.owl#shortDisplayName	eupath/eupath.owl#description	eupath/eupath.owl#geneOrTranscript	EUPATH_0000274	eupath/eupath.owl#scope	eupath/eupath.owl#scope	eupath/eupath.owl#scope
 topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	Data Provenance	DP	Data submission, annotation and curation		3	internal		
-topic_3365_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_analysis	Data Analysis	DA	Data architecture, analysis and design		4	internal		
+topic_3308_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			comparative_transcriptomics	Comparative transcriptomics	CT	Data context		2	internal		
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
-DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3365	Data Analysis	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
-DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
-DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
-DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
-DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
+DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -7,6 +7,7 @@ DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/to
 DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -6,6 +6,7 @@ DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Cur
 DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
 DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -1,11 +1,11 @@
  			recordClassName	targetType	name	displayName	shortDisplayName	description	geneOrTranscript	displayOrder	scope	scope	scope
 			eupath/eupath.owl#recordClassName	eupath/eupath.owl#targetType	eupath/eupath.owl#name	EUPATH_0000052	eupath/eupath.owl#shortDisplayName	eupath/eupath.owl#description	eupath/eupath.owl#geneOrTranscript	EUPATH_0000274	eupath/eupath.owl#scope	eupath/eupath.owl#scope	eupath/eupath.owl#scope
 topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	Data Provenance	DP	Data submission, annotation and curation		3	internal		
-topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_context	Data Context	DC	Data submission, annotation and curation		4	internal		
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
 DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
-DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	topic_0219_synonym	Data Context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -1,9 +1,10 @@
  			recordClassName	targetType	name	displayName	shortDisplayName	description	geneOrTranscript	displayOrder	scope	scope	scope
 			eupath/eupath.owl#recordClassName	eupath/eupath.owl#targetType	eupath/eupath.owl#name	EUPATH_0000052	eupath/eupath.owl#shortDisplayName	eupath/eupath.owl#description	eupath/eupath.owl#geneOrTranscript	EUPATH_0000274	eupath/eupath.owl#scope	eupath/eupath.owl#scope	eupath/eupath.owl#scope
 topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	Data Provenance	DP	Data submission, annotation and curation		3	internal		
+topic_3365_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_analysis	Data Analysis	DA	Data architecture, analysis and design		4	internal		
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
-DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3365	Data Analysis	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
 DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -27,11 +27,13 @@ DatasetRecordClasses.DatasetRecordClass.primary_key	topic_0219_synonym		DatasetR
 DatasetRecordClasses.DatasetRecordClass.bulk_download_url	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	bulk_download_url						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.genecounts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	genecounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_prefix						results	record-internal	
+DatasetRecordClasses.DatasetRecordClass.megabase_pairs	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	megabase_pairs						results	record-internal	
 DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_download								download
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download
 DatasetRecordClasses.DatasetRecordClass.category	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	category						results	record	
 DatasetRecordClasses.DatasetRecordClass.newcategory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	newcategory						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	version					19	results	record	download
+DatasetRecordClasses.DatasetRecordClass.genecount	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	attribute	genecount					19	results	record	download
 DatasetRecordClasses.DatasetRecordClass.dataset_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_id								
 DatasetRecordClasses.DatasetRecordClass.dataset_name	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_name								
 DatasetRecordClasses.DatasetRecordClass.dataset_name_pattern	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_name_pattern								

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -4,6 +4,7 @@ topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	D
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
 DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
+DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -32,7 +32,7 @@ DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Cur
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download
 DatasetRecordClasses.DatasetRecordClass.category	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	category						results	record	
 DatasetRecordClasses.DatasetRecordClass.newcategory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	newcategory						results	record-internal	download
-DatasetRecordClasses.DatasetRecordClass.version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	version					19	results	record	download
+DatasetRecordClasses.DatasetRecordClass.version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	version					19	results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.genecount	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	attribute	genecount					19	results	record	download
 DatasetRecordClasses.DatasetRecordClass.dataset_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_id								
 DatasetRecordClasses.DatasetRecordClass.dataset_name	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_name								

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -25,6 +25,7 @@ DatasetRecordClasses.DatasetRecordClass.AccessRequest	topic_0219_synonym	Curatio
 DatasetRecordClasses.DatasetRecordClass.DatasetGeneTable	http://edamontology.org/topic_3345	Data identity and mapping	DatasetRecordClasses.DatasetRecordClass	table	DatasetGeneTable								download
 DatasetRecordClasses.DatasetRecordClass.primary_key	topic_0219_synonym		DatasetRecordClasses.DatasetRecordClass	attribute	primary_key					1	results		download
 DatasetRecordClasses.DatasetRecordClass.bulk_download_url	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	bulk_download_url						results	record-internal	download
+DatasetRecordClasses.DatasetRecordClass.genecounts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	genecounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_prefix						results	record-internal	
 DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_download								download
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -1,10 +1,11 @@
  			recordClassName	targetType	name	displayName	shortDisplayName	description	geneOrTranscript	displayOrder	scope	scope	scope
 			eupath/eupath.owl#recordClassName	eupath/eupath.owl#targetType	eupath/eupath.owl#name	EUPATH_0000052	eupath/eupath.owl#shortDisplayName	eupath/eupath.owl#description	eupath/eupath.owl#geneOrTranscript	EUPATH_0000274	eupath/eupath.owl#scope	eupath/eupath.owl#scope	eupath/eupath.owl#scope
 topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	Data Provenance	DP	Data submission, annotation and curation		3	internal		
+topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_context	Data Context	DC	Data submission, annotation and curation		4	internal		
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
 DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
-DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3345	Linkouts	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	topic_0219_synonym	Data Context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -29,7 +29,7 @@ DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curat
 DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_download								download
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download
 DatasetRecordClasses.DatasetRecordClass.category	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	category						results	record	
-DatasetRecordClasses.DatasetRecordClass.newcategory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	newcategory						results	record	download
+DatasetRecordClasses.DatasetRecordClass.newcategory	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	newcategory						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	version					19	results	record	download
 DatasetRecordClasses.DatasetRecordClass.dataset_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_id								
 DatasetRecordClasses.DatasetRecordClass.dataset_name	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	dataset_name								

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -27,7 +27,10 @@ DatasetRecordClasses.DatasetRecordClass.primary_key	topic_0219_synonym		DatasetR
 DatasetRecordClasses.DatasetRecordClass.bulk_download_url	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	bulk_download_url						results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.genecounts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	genecounts						results	record	download
 DatasetRecordClasses.DatasetRecordClass.organism_prefix	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_prefix						results	record-internal	
-DatasetRecordClasses.DatasetRecordClass.megabase_pairs	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	megabase_pairs						results	record-internal	
+DatasetRecordClasses.DatasetRecordClass.megabase_pairs	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	megabase_pairs							record-internal	
+DatasetRecordClasses.DatasetRecordClass.genome_version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	genome_version							record-internal	
+DatasetRecordClasses.DatasetRecordClass.annotation_version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	annotation_version							record-internal	
+DatasetRecordClasses.DatasetRecordClass.functional_annotation_version	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	functional_annotation_version							record-internal	
 DatasetRecordClasses.DatasetRecordClass.organism_download	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	organism_download								download
 DatasetRecordClasses.DatasetRecordClass.project_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	project_id						results	record	download
 DatasetRecordClasses.DatasetRecordClass.category	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	category						results	record	

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -1,15 +1,15 @@
  			recordClassName	targetType	name	displayName	shortDisplayName	description	geneOrTranscript	displayOrder	scope	scope	scope
 			eupath/eupath.owl#recordClassName	eupath/eupath.owl#targetType	eupath/eupath.owl#name	EUPATH_0000052	eupath/eupath.owl#shortDisplayName	eupath/eupath.owl#description	eupath/eupath.owl#geneOrTranscript	EUPATH_0000274	eupath/eupath.owl#scope	eupath/eupath.owl#scope	eupath/eupath.owl#scope
 topic_0219_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_provenance	Data Provenance	DP	Data submission, annotation and curation		3	internal		
-topic_3308_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			comparative_transcriptomics	Comparative transcriptomics	CT	Data context		2	internal		
+topic_3308_synonym	http://www.w3.org/2002/07/owl#Thing	Thing			data_context	Data Context	DC	Data context		5	internal		
 DatasetRecordClasses.DatasetReleaseNotes.primary_key			DatasetRecordClasses.DatasetReleaseNotes	attribute	primary_key						results	record	download
 DatasetRecordClasses.DatasetReleaseNotes.release_notes_id	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetReleaseNotes	attribute	release_notes_id								
-DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
-DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
-DatasetRecordClasses.DatasetRecordClass.GeneTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	GeneTypeCounts						results	record	download
-DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
-DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
-DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3308	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExampleGraphs	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	table	ExampleGraphs						results	record	download
+DatasetRecordClasses.DatasetRecordClass.TranscriptTypeCounts	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	table	TranscriptTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.GeneTypeCounts	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	table	GeneTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.SequenceTypeCounts	topic_3308_synonym	Data context	DatasetRecordClasses.DatasetRecordClass	table	SequenceTypeCounts						results	record	download
+DatasetRecordClasses.DatasetRecordClass.GenomeAssociatedData	http://edamontology.org/topic_3345	Link Outs	DatasetRecordClasses.DatasetRecordClass	table	GenomeAssociatedData						results	record	download
+DatasetRecordClasses.DatasetRecordClass.ExternalDatabases	http://edamontology.org/topic_3345	Link Outs	DatasetRecordClasses.DatasetRecordClass	table	ExternalDatabases						results	record	download
 DatasetRecordClasses.DatasetRecordClass.DownloadVersion	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	DownloadVersion					21	results	record	download
 DatasetRecordClasses.DatasetRecordClass.Contacts	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	Contacts					22	results	record	download
 DatasetRecordClasses.DatasetRecordClass.StudyCharacteristicTable	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	table	StudyCharacteristicTable					18	results	record	download


### PR DESCRIPTION
The goal of this PR is to collect and simplify data shown on the dataset record pages. 

_Relies on associated PRs [56](https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/56) in EbrcWebsiteCommon and [29](https://github.com/VEuPathDB/ApiCommonWebsite/pull/29) in ApiCommonWebsite_

## Major Updates
- Most interesting attributes/tables from Organism page have been moved to the relevant primary_genome dataset record page.
- Added "Data context" section to relevant dataset record pages.
- Added additional external references tables.
- Added attributes/tables used exclusively by Genomics pages (requires [1], [2])

## Notes
- The new `GenomicsDatasetAttributes` query in dataset.xml could possibly be incorporated into the `DatasetDisplayName` because it uses the same join.
- The decoder for `id_url` in the `ExternalDatabases` query is incomplete. There are still cases where the truncated link does not work, we just do not have appropriate replacements yet.