### PR TITLE
Add "Explore and analyze" column to "All Studies" table for clinepi sites

### DIFF
--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -180,6 +180,18 @@ while in protected and private studies there will be human intervention in the d
          <columnAttribute name="request_email_bcc" internal="true"/>
          <columnAttribute name="request_email_body" internal="true"/>
          <columnAttribute name="request_needs_approval" internal="true"/>
+         <linkAttribute name="analyze" displayName="Explore &amp; analyze" sortable="false" includeProjects="ClinEpiDB,AllClinEpiDB">
+           <displayText>
+             <![CDATA[
+               <div style="text-align: center">
+                 <i style="color: black; font-size: 2em;" class="ebrc-icon-edaIcon"></i>
+               </div>
+             ]]>
+           </displayText>
+           <url>
+             @WEBAPP_BASE_URL@/workspace/analyses/$$dataset_id$$/~latest
+           </url>
+         </linkAttribute>
        </attributeQueryRef>
 
 
@@ -268,7 +280,7 @@ while in protected and private studies there will be human intervention in the d
                         includeProjects="EuPathDB"/>
 
       <!--  <attributesList summary="disease,study_access,card_questions,eupath_release,total,approved,percent_approved"-->
-        <attributesList summary="disease,Study_Type,Study_Design,Part_count,Country,Years,study_access,card_questions"
+        <attributesList summary="analyze,disease,Study_Type,Study_Design,Part_count,Country,Years,study_access"
 			includeProjects="ClinEpiDB,AllClinEpiDB"/>
 
 	<attributesList summary="study_categories,summary,eupath_release,card_questions"

--- a/Model/lib/wdk/ontology/commonIndividuals.txt
+++ b/Model/lib/wdk/ontology/commonIndividuals.txt
@@ -61,7 +61,9 @@ DatasetRecordClasses.DatasetRecordClass.email	topic_0219_synonym	Curation and An
 DatasetRecordClasses.DatasetRecordClass.short_attribution	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	short_attribution								download
 DatasetRecordClasses.DatasetRecordClass.exp_technique	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	exp_technique						results	record	download
 DatasetRecordClasses.DatasetRecordClass.study_access	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	study_access					1	results	record	download
-DatasetRecordClasses.DatasetRecordClass.card_questions	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	card_questions					1	results		
+## card_questions is removed from here so it does not show up in the All Studies table by default. Sites that want it should add it to their own individuals.txt file.
+## DatasetRecordClasses.DatasetRecordClass.card_questions	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	card_questions					1	results		
+DatasetRecordClasses.DatasetRecordClass.analyze	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	analyze					1	results		
 DatasetRecordClasses.DatasetRecordClass.total	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	total					9	results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.approved	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	approved					9	results	record-internal	download
 DatasetRecordClasses.DatasetRecordClass.percent_approved	topic_0219_synonym	Curation and Annotation	DatasetRecordClasses.DatasetRecordClass	attribute	percent_approved					9	results	record-internal	download


### PR DESCRIPTION
This PR adds the new attribute to clinepi sites. It also removes `card_questions` from the shared individuals file. This prevents that attribute from appearing as an available column in the "All Studies" table.

partially addresses https://github.com/VEuPathDB/web-eda/issues/414