### PR TITLE
update category to DNA Microarray Assay

### DIFF
--- a/Model/lib/wdk/ontology/annotation.txt
+++ b/Model/lib/wdk/ontology/annotation.txt
@@ -49,7 +49,7 @@ Sequence search	http://edamontology.org/topic_3346	Sequence search	117
 NA Sequence	http://edamontology.org/data_2977	Nucleic acid sequence	118
 Protein Sequence	http://edamontology.org/data_2976	Protein sequence	119
 Sequence sites, features and motifs	http://edamontology.org/topic_0160	Sequence sites, features and motifs	120
-DNA Microarray	http://purl.obolibrary.org/obo/OBI_0400148	DNA Microarray	121
+DNA Microarray	http://purl.obolibrary.org/obo/OBI_0001985	DNA Microarray Assay	121
 RNASeq	http://purl.obolibrary.org/obo/OBI_0001271	RNASeq	122
 RT PCR	http://purl.obolibrary.org/obo/OBI_0001361	RT PCR	123
 EST	http://purl.obolibrary.org/obo/SO_0000345	EST	124

--- a/Model/lib/wdk/ontology/categories.owl
+++ b/Model/lib/wdk/ontology/categories.owl
@@ -1070,9 +1070,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/OBI_0400148 -->
+    <!-- http://purl.obolibrary.org/obo/OBI_0001985 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0400148">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001985">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA microarray</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3308"/>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>

--- a/Model/lib/wdk/ontology/datasetClassCategories.txt
+++ b/Model/lib/wdk/ontology/datasetClassCategories.txt
@@ -120,8 +120,8 @@ antiCodon	http://edamontology.org/topic_0160	sequence sites, features and motifs
 eupathOntologyTerms	http://edamontology.org/topic_0089	Ontology and Terminology	sres	
 GeneImage	http://edamontology.org/topic_0140	Protein targeting and localization	subcellular_localization	
 orthomclClades	http://edamontology.org/topic_3299	orthology	taxonomy	
-microarrayExpressionExperiment	http://purl.obolibrary.org/obo/OBI_0400148	Microarray Assay	transcript_expression	array
-microarrayExpressionExperimentWithProviderProbeMapping	http://purl.obolibrary.org/obo/OBI_0400148	Microarray Assay	transcript_expression	array
+microarrayExpressionExperiment	http://purl.obolibrary.org/obo/OBI_0001985	Microarray Assay	transcript_expression	array
+microarrayExpressionExperimentWithProviderProbeMapping	http://purl.obolibrary.org/obo/OBI_0001985	Microarray Assay	transcript_expression	array
 chipChipExperiment	http://purl.obolibrary.org/obo/OBI_0001248	chipchip	transcript_expression	chip_chip
 chipChipSample	http://purl.obolibrary.org/obo/OBI_0001248	chipchip	transcript_expression	chip_chip
 chipSeqExperiment	http://purl.obolibrary.org/obo/OBI_0000716	chipseq	transcript_expression	chipseq

--- a/Model/lib/wdk/ontology/ontofox_input
+++ b/Model/lib/wdk/ontology/ontofox_input
@@ -214,7 +214,7 @@ OBI
 [Low level source term URIs]
 http://purl.obolibrary.org/obo/OBI_0002029 # SAGE
 http://purl.obolibrary.org/obo/OBI_0001204 #SNP Microarray
-http://purl.obolibrary.org/obo/OBI_0400148 #DNA Microarray
+http://purl.obolibrary.org/obo/OBI_0001985 #DNA Microarray
 http://purl.obolibrary.org/obo/OBI_0001271 #RNASeq
 http://purl.obolibrary.org/obo/SO_0000345 # EST
 http://purl.obolibrary.org/obo/OBI_0001361 # RT PCR
@@ -229,7 +229,7 @@ http://purl.obolibrary.org/obo/OBI_0001204 #SNP Microarray
 subClassOf http://edamontology.org/topic_2885 # DNA polymorphism
 http://purl.obolibrary.org/obo/OBI_0001247 # NGS SNP
 subClassOf http://edamontology.org/topic_2885 # DNA polymorphism
-http://purl.obolibrary.org/obo/OBI_0400148 #DNA Microarray
+http://purl.obolibrary.org/obo/OBI_0001985 #DNA Microarray
 subClassOf http://edamontology.org/topic_3308 #Transcriptomics
 http://purl.obolibrary.org/obo/OBI_0002029 # SAGE
 subClassOf http://edamontology.org/topic_3308 #Transcriptomics


### PR DESCRIPTION
Addresses redmine #44133

Changes the dataset category "DNA Microarray" display name to "DNA Microarray Assay". Additionally updates the relevant ontology identifier.