### PR TITLE
change study summaries table display name

### DIFF
--- a/Model/lib/wdk/model/questions/datasetQuestions.xml
+++ b/Model/lib/wdk/model/questions/datasetQuestions.xml
@@ -32,7 +32,7 @@
     </question>
 
     <question name="Studies"
-      displayName="Studies"
+      displayName="Study summaries"
       shortDisplayName="Studies"
       fullAnswer="true"
       queryRef="DatasetIds.AllDatasets"


### PR DESCRIPTION
Addresses web-eda [#591](https://github.com/VEuPathDB/web-eda/issues/591)

Changes the display name of the study summaries table to "Study summaries", in order to better align the display name with other places on the site that reference this table (buttons, etc).

<img width="1343" alt="Screen Shot 2021-11-12 at 6 49 08 PM" src="https://user-images.githubusercontent.com/11710234/141596514-2382bdef-1732-490e-a016-b176728c8e1b.png">


