### PR TITLE
make sure N/A's sort different than 0's

### DIFF
--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -1143,9 +1143,9 @@ where pres.dataset_presenter_id = dp.dataset_presenter_id(+)
 
        <sqlQuery name="StudyReqStats"  isCacheable="false" includeProjects="ClinEpiDB">
         <column name="dataset_id" columnType="string"/>
-        <column name="total" columnType="number" sortingColumn="total_number" />
-        <column name="approved" columnType="number" sortingColumn="approved_number" />
-        <column name="percent_approved" columnType="number" sortingColumn="percent_approved_number" />
+        <column name="total"  sortingColumn="total_number" />
+        <column name="approved" sortingColumn="approved_number" />
+        <column name="percent_approved"  sortingColumn="percent_approved_number" />
         <column name="total_number" columnType="number"/>
         <column name="approved_number" columnType="number"/>
         <column name="percent_approved_number" columnType="number"/>
@@ -1154,18 +1154,18 @@ where pres.dataset_presenter_id = dp.dataset_presenter_id(+)
           <![CDATA[
 select dataset_id, 
        CASE
-         WHEN dp.value in ('public','prerelease') THEN 0
-         WHEN total_number is null THEN 0.5
+         WHEN dp.value in ('public','prerelease') THEN 0.5
+         WHEN total_number is null THEN 0.1
          ELSE total_number
        END as total_number,
        CASE
-         WHEN dp.value in ('public','prerelease') THEN 0
-         WHEN approved_number is null THEN 0.5
+         WHEN dp.value in ('public','prerelease') THEN 0.5
+         WHEN approved_number is null THEN 0.1
          ELSE approved_number
        END as approved_number,
        CASE
-         WHEN dp.value in ('public','prerelease') THEN 0
-         WHEN percent_approved_number is null THEN 0.5
+         WHEN dp.value in ('public','prerelease') THEN 0.5
+         WHEN percent_approved_number is null THEN 0.1
          ELSE percent_approved_number
        END as percent_approved_number,
        CASE


### PR DESCRIPTION
addresses https://github.com/VEuPathDB/ClinEpiWebsite/issues/67
fixing the backend sorting for when we use the wdk table. 

i think we could remove  type = "number" in the attributeQueryRef ref="DatasetAttributes.StudyReqStats", 
on the 3 internal number columns used for wdk sorting;
i think type is used only by the client but we dont show these columns.