### PR TITLE
Remove space from pubmed link attribute's name property

### DIFF
--- a/Model/lib/wdk/model/records/datasetRecords.xml
+++ b/Model/lib/wdk/model/records/datasetRecords.xml
@@ -869,7 +869,7 @@ Based on evolutionarily informed expectations of gene content of near-universal 
         <columnAttribute name="webapp_name" internal="true"/>
         <columnAttribute name="display_name" internal="true"/>
 
-        <linkAttribute displayName="PubMed ID" name="pubmed link"
+        <linkAttribute displayName="PubMed ID" name="pubmed_link"
                        internal="false">
              <displayText>
                 <![CDATA[


### PR DESCRIPTION
Handles the second model change as described in the second `Model changes` task from https://github.com/VEuPathDB/web-monorepo/issues/921