### PR TITLE
dnaseq Experiment

### DIFF
--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -7085,6 +7085,37 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
   </datasetLoader>
   </datasetClass>  
 
+  <!-- New dataset class replacing dnaSeqExperimentFromAccession and dnaSeqExperimentFromLocal.
+       Uses nf-core samplesheet convention; fromSRA and ploidy are per-dataset props.
+       taxonId is looked up at runtime from the DB in MakeDnaSeqNextflowConfig. -->
+  <datasetClass class="dnaseqExperiment" category="" datasetFileHint="">
+    <purpose></purpose>
+    <prop name="projectName">&projectName;</prop>
+    <prop name="organismAbbrev">&organismAbbrev;</prop>
+    <prop name="name">&name;</prop>
+    <prop name="version">&version;</prop>
+    <prop name="fromSRA"></prop>
+    <prop name="ploidy"></prop>
+    <graphTemplateFile name="dnaseq.xml"/>
+    <datasetLoader datasetName="${organismAbbrev}_${name}_dnaseqExperiment_RSRC" version="${version}"
+          plugin="ApiCommonData::Load::Plugin::LoadNothing"
+              scope="organism"
+              type="isolates"
+              subType="Dna_Seq"
+              organismAbbrev="${organismAbbrev}">
+      <manualGet fileOrDir="common/empty">
+        <dir name="final">
+        </dir>
+      </manualGet>
+      <unpack>ln -s @@manualDeliveryDir@@/${projectName}/${organismAbbrev}/dnaSeq/${name}/${version}/final/ @@dataDir@@/final</unpack>
+      <getAndUnpackOutput dir="@@dataDir@@/final"/>
+      <getAndUnpackOutput file="@@dataDir@@/final/samplesheet.csv"/>
+      <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
+    </datasetLoader>
+  </datasetClass>
+
+  <!-- DEPRECATED - replaced by dnaseqExperiment above.
+       Retain until all organism dataset XMLs are migrated. -->
   <datasetClass class="dnaSeqExperimentFromAccession" category="" datasetFileHint="">
     <purpose></purpose>
     <prop name="projectName">&projectName;</prop>
@@ -7115,7 +7146,8 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
 
   </datasetClass>
 
-
+  <!-- DEPRECATED - replaced by dnaseqExperiment above.
+       Retain until all organism dataset XMLs are migrated. -->
   <datasetClass class="dnaSeqExperimentFromLocal" category="" datasetFileHint="">
     <purpose></purpose>
     <prop name="projectName">&projectName;</prop>

--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -7114,69 +7114,6 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
     </datasetLoader>
   </datasetClass>
 
-  <!-- DEPRECATED - replaced by dnaseqExperiment above.
-       Retain until all organism dataset XMLs are migrated. -->
-  <datasetClass class="dnaSeqExperimentFromAccession" category="" datasetFileHint="">
-    <purpose></purpose>
-    <prop name="projectName">&projectName;</prop>
-    <prop name="organismAbbrev">&organismAbbrev;</prop>
-    <prop name="name">&name;</prop>
-    <prop name="version">&version;</prop>
-    <prop name="isPaired"></prop>
-    <prop name="ploidy"></prop>
-    <prop name="fromBAM"></prop>
-    <prop name="isLocal"></prop>
-    <prop name="taxonId"></prop>
-    <graphTemplateFile name="dnaseq.xml"/>
-
-    <datasetLoader datasetName="${organismAbbrev}_dnaseqExperiment_${name}_RSRC" version="${version}"
-          plugin="ApiCommonData::Load::Plugin::LoadNothing"
-              scope="organism"
-              type="isolates"
-              subType="Dna_Seq"
-              organismAbbrev="${organismAbbrev}">
-      <manualGet fileOrDir="${projectName}/${organismAbbrev}/dnaSeq/${name}/${version}/final/accessions.tsv">
-        <dir name="final">
-        </dir>
-      </manualGet>
-      <getAndUnpackOutput file="@@dataDir@@/accessions.tsv"/>
-
-      <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
-    </datasetLoader>
-
-  </datasetClass>
-
-  <!-- DEPRECATED - replaced by dnaseqExperiment above.
-       Retain until all organism dataset XMLs are migrated. -->
-  <datasetClass class="dnaSeqExperimentFromLocal" category="" datasetFileHint="">
-    <purpose></purpose>
-    <prop name="projectName">&projectName;</prop>
-    <prop name="organismAbbrev">&organismAbbrev;</prop>
-    <prop name="name">&name;</prop>
-    <prop name="version">&version;</prop>
-    <prop name="isPaired"></prop>
-    <prop name="ploidy"></prop>
-    <prop name="fromBAM"></prop>
-    <prop name="isLocal"></prop>
-    <prop name="taxonId"></prop>
-    <graphTemplateFile name="dnaseq.xml"/>
-
-    <datasetLoader datasetName="${organismAbbrev}_dnaseqExperiment_${name}_RSRC" version="${version}"
-          plugin="ApiCommonData::Load::Plugin::LoadNothing"
-              scope="organism"
-              type="isolates"
-              subType="Dna_Seq"
-              organismAbbrev="${organismAbbrev}">
-      <manualGet fileOrDir="${projectName}/${organismAbbrev}/dnaSeq/${name}/${version}/final/">
-        <dir name="final">
-        </dir>
-      </manualGet>
-      <getAndUnpackOutput file="@@dataDir@@/final"/>
-
-      <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
-    </datasetLoader>
-
-  </datasetClass>
 
   <!-- New dataset class for the long read RNA Seq -->
   <datasetClass class="longReadRnaSeqExperiment" category="" datasetFileHint="">

--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -7107,7 +7107,7 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
         <dir name="final">
         </dir>
       </manualGet>
-      <unpack>ln -s @@manualDeliveryDir@@/${projectName}/${organismAbbrev}/dnaSeq/${name}/${version}/final/ @@dataDir@@/final</unpack>
+      <unpack>ln -s @@manualDeliveryDir@@/${projectName}/${organismAbbrev}/SNP/${name}/${version}/final/ @@dataDir@@/final</unpack>
       <getAndUnpackOutput dir="@@dataDir@@/final"/>
       <getAndUnpackOutput file="@@dataDir@@/final/samplesheet.csv"/>
       <pluginArgs>--dbRefExternalDatabaseSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>


### PR DESCRIPTION
New class uses nf-core samplesheet convention with fromSRA and ploidy as per-dataset props. taxonId removed (looked up at runtime). Old dnaSeqExperimentFromAccession and dnaSeqExperimentFromLocal retained with DEPRECATED comments pending organism XML migration.