### PR TITLE
Antibody array WDK: inject EDA attribute and gene table templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules/
 # Exported from svn:ignore
 target
 *~
+.worktrees

--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
@@ -22,6 +22,11 @@ public class AntibodyArrayEDAStudy extends GenomicsEDAStudy {
         setPropValue("datasetDisplayName", trimmedDatasetDisplayName);
 
         injectTemplate("antibodyArrayEdaQuestion");
+        injectTemplate("antibodyArrayEdaAttributeQueriesNumeric");
+        injectTemplate("antibodyArrayEdaAttributeRef");
+        injectTemplate("antibodyArrayEdaAttributeCategory");
+        injectTemplate("antibodyArrayEdaGeneTableSql");
+        injectTemplate("antibodyArrayDataTableGeneTableSql");
 
         setPropValue("questionName", getInternalQuestionName());
         setPropValue("searchCategory", "searchCategory-T-test-2-sample-unequal-variance");
@@ -33,6 +38,8 @@ public class AntibodyArrayEDAStudy extends GenomicsEDAStudy {
         super.addModelReferences();
 
         addWdkReference("TranscriptRecordClasses.TranscriptRecordClass", "question", "GeneQuestions.GenesByAntibodyArrayEdaSubset_" + this.getDatasetName());
+        addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "EdaAntibodyArrayDatasets");
+        addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "EdaAntibodyArrayGraphsDataTable");
     }
 
 }


### PR DESCRIPTION
## Summary

- Update `AntibodyArrayEDAStudy.java` to inject 5 new DST templates:
  - `antibodyArrayEdaAttributeQueriesNumeric` — normalized intensity transcript columns
  - `antibodyArrayEdaAttributeRef` — transcript record attribute query reference
  - `antibodyArrayEdaAttributeCategory` — ontology entries
  - `antibodyArrayEdaGeneTableSql` — gene table dataset UNION
  - `antibodyArrayDataTableGeneTableSql` — gene table data UNION
- Add WDK model references for `EdaAntibodyArrayDatasets` and `EdaAntibodyArrayGraphsDataTable` on `GeneRecordClass`

## Context

The template content lives in `ApiCommonModel/antibodyArray.dst`. The transcript crosstab pivots on `sample_stable_id` (one column per sample/gene), distinct from the Phenotype pattern which pivots on `attribute_stable_id`.

## Test Plan

- [ ] Build and deploy alongside companion ApiCommonModel PR
- [ ] Transcript record: intensity columns appear per sample
- [ ] Gene record: Antibody Array Datasets and graph data table appear

Companion PR: VEuPathDB/ApiCommonModel#177

🤖 Generated with [Claude Code](https://claude.com/claude-code)