### PR TITLE
Swap `javascript:void(0)` for a safe URL that won't be sanitized

### DIFF
--- a/Model/lib/wdk/model/records/genomeDatasetQueries.xml
+++ b/Model/lib/wdk/model/records/genomeDatasetQueries.xml
@@ -209,7 +209,7 @@ SUBSTRING(tn.organism_name FROM LENGTH(split_part(tn.organism_name, ' ', 1) || '
               END AS isin_apollo,
                     CASE WHEN dh.genome_version LIKE 'G%'
                       THEN 'https://www.ncbi.nlm.nih.gov/data-hub/genome/' || dh.genome_version
-                      ELSE 'javascript:void(0);'
+                      ELSE '#'
                     END AS assembly_url
 
           FROM


### PR DESCRIPTION
Related to https://github.com/VEuPathDB/web-monorepo/pull/1731

Front end will sanitize `javascript:void(0)` and the resulting link may be unclickable. Replace with `#` on the back end and all should be good.

find|grep didn't find any other `javascript:`, `<script>` or `<iframe>` tags in this repo.


Not even sure this `assembly_url` is rendered anywhere!

https://github.com/search?q=org%3AVEuPathDB+assembly_url&type=code
