### PR TITLE
Add geneCoExpression datasetClass

### DIFF
--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -2884,7 +2884,7 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
     <prop name="experimentName">The name of the experiment; forms part of the dataset name and the manual-delivery path.</prop>
     <prop name="experimentVersion">The version of the experiment, typically a release number or a date in yyyy-mm-dd format.</prop>
 
-    <graphTemplateFile name="organismSpecificMiscNoAlias.xml"/>
+    <graphTemplateFile name="organismSpecificMisc.xml"/>
 
     <datasetLoader datasetName="${organismAbbrev}_${experimentName}_geneCoexpression_RSRC"
               version="${experimentVersion}"

--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -2894,11 +2894,12 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
               subType="coexpression"
               organismAbbrev="${organismAbbrev}">
 
-      <manualGet fileOrDir="${projectName}/${organismAbbrev}/${assayType}/${experimentName}/${experimentVersion}/final/gene_coexpression.txt">
+      <manualGet fileOrDir="${projectName}/${organismAbbrev}/${assayType}/${experimentName}/${experimentVersion}/final/gene_coexpression.txt.gz">
         <dir name="final">
         </dir>
       </manualGet>
 
+      <unpack>gunzip -d @@dataDir@@/gene_coexpression.txt.gz</unpack>
       <pluginArgs>--inputFile @@dataDir@@/gene_coexpression.txt --extDbRlsSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
     </datasetLoader>
   </datasetClass>

--- a/Model/lib/xml/datasetClass/classes.xml
+++ b/Model/lib/xml/datasetClass/classes.xml
@@ -2876,6 +2876,32 @@ where e.na_sequence_id = ns.na_sequence_id and ns.external_database_release_id =
   </datasetClass>
 
 
+  <datasetClass class="geneCoExpression" category="" datasetFileHint="">
+    <purpose></purpose>
+    <prop name="projectName">&projectName;</prop>
+    <prop name="organismAbbrev">&organismAbbrev;</prop>
+    <prop name="assayType">The assay type subdirectory in manual delivery under which this experiment lives, e.g. 'rnaseq'.</prop>
+    <prop name="experimentName">The name of the experiment; forms part of the dataset name and the manual-delivery path.</prop>
+    <prop name="experimentVersion">The version of the experiment, typically a release number or a date in yyyy-mm-dd format.</prop>
+
+    <graphTemplateFile name="organismSpecificMiscNoAlias.xml"/>
+
+    <datasetLoader datasetName="${organismAbbrev}_${experimentName}_geneCoexpression_RSRC"
+              version="${experimentVersion}"
+              plugin="ApiCommonData::Load::Plugin::InsertGeneCoexpression"
+              scope="organism"
+              type="transcript_expression"
+              subType="coexpression"
+              organismAbbrev="${organismAbbrev}">
+
+      <manualGet fileOrDir="${projectName}/${organismAbbrev}/${assayType}/${experimentName}/${experimentVersion}/final/gene_coexpression.txt">
+        <dir name="final">
+        </dir>
+      </manualGet>
+
+      <pluginArgs>--inputFile @@dataDir@@/gene_coexpression.txt --extDbRlsSpec "%DATASET_NAME%|%DATASET_VERSION%"</pluginArgs>
+    </datasetLoader>
+  </datasetClass>
 
 
   <datasetClass class="NAFeaturePhenotypeImage" category="phenotype" datasetFileHint="">


### PR DESCRIPTION
## Summary
Adds a new `geneCoExpression` datasetClass to `Model/lib/xml/datasetClass/classes.xml` for loading per-organism gene coexpression datasets.

- Uses the `InsertGeneCoexpression` plugin (defined on the ApiCommonData `gene-coexpression-loader` branch).
- Modeled structurally on the `Cellxgene` class: `scope="organism"`, `type="transcript_expression"`, `subType="coexpression"`.
- Graph template: `organismSpecificMiscNoAlias.xml`.
- Props: `projectName`, `organismAbbrev`, `assayType`, `experimentName`, `experimentVersion`.
- Manual-delivery path: `${projectName}/${organismAbbrev}/${assayType}/${experimentName}/${experimentVersion}/final/gene_coexpression.txt`.
- pluginArgs: `--inputFile @@dataDir@@/gene_coexpression.txt --extDbRlsSpec "%DATASET_NAME%|%DATASET_VERSION%"` (targetSchema defaults to `apidb`).

## Dependencies / merge notes
- Requires the `InsertGeneCoexpression` plugin from **ApiCommonData** branch `gene-coexpression-loader` — the two branches are a matched pair and should merge together.
- Assumes the `organismSpecificMiscNoAlias.xml` graph template exists in the graph-resolution path.

## Testing
- `xmllint --noout` confirms `classes.xml` is well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)