### PR TITLE
retry throttled PMC API requests in pubmedIdToCitation

### DIFF
--- a/Model/bin/pubmedIdToCitation
+++ b/Model/bin/pubmedIdToCitation
@@ -2,22 +2,26 @@
 
 use lib "$ENV{GUS_HOME}/lib/perl";
 
-use LWP::Simple;
+use LWP::UserAgent;
 use JSON::PP;
 
 use Encode;
 
 use strict;
 
+# NCBI throttles unauthenticated clients at ~3 requests/sec. A full presenter
+# load resolves well over a thousand ids, so transient 429s are expected and
+# must be retried rather than aborting the whole load.
+my $MAX_ATTEMPTS = 5;
+my $TIMEOUT = 30;
+my $MAX_BACKOFF = 60;
+
 &usage unless scalar(@ARGV) == 1;
 my $pubmedId = $ARGV[0];
 
 my $pmcApiUrl = "https://pmc.ncbi.nlm.nih.gov/api/ctxp/v1/pubmed/?format=citation&id=" . $pubmedId;
 
-my $content = LWP::Simple::get($pmcApiUrl);
-
-die "PMC API did not return a valid response for pubmed id \"$pubmedId\". Request URL was \"$pmcApiUrl\""
-  unless $content;
+my $content = &fetchWithRetry($pmcApiUrl, $pubmedId);
 
 my $json;
 eval {
@@ -39,6 +43,52 @@ die "Response does not contain MLA citation for pubmed id \"$pubmedId\""
 my $citation = $json->{mla}->{orig};
 
 print "$citation\n";
+
+sub fetchWithRetry {
+    my ($url, $pubmedId) = @_;
+
+    my $ua = LWP::UserAgent->new(timeout => $TIMEOUT);
+    $ua->agent("EbrcModelCommon/pubmedIdToCitation (https://veupathdb.org)");
+    $ua->env_proxy;
+
+    my $lastError;
+
+    for (my $attempt = 1; $attempt <= $MAX_ATTEMPTS; $attempt++) {
+
+        my $response = $ua->get($url);
+
+        # Deliberately ->content, not ->decoded_content: the caller reads our
+        # stdout as UTF-8, so pass the undecoded bytes straight through.
+        return $response->content if $response->is_success;
+
+        my $status = $response->code;
+        $lastError = $status . " " . $response->message;
+
+        # 4xx other than 429 means the request itself is wrong (bad or unknown
+        # id) -- retrying cannot help, so fail immediately.
+        if ($status >= 400 && $status < 500 && $status != 429) {
+            die "PMC API returned $lastError for pubmed id \"$pubmedId\". Request URL was \"$url\"";
+        }
+
+        last if $attempt == $MAX_ATTEMPTS;
+
+        # Retry-After is optional and may be a date rather than a delay; only
+        # trust it when it is a plain number of seconds.
+        my $retryAfter = $response->header('Retry-After');
+        my $backoff = (defined $retryAfter && $retryAfter =~ /^\s*(\d+)\s*$/)
+                      ? $1
+                      : 2 ** ($attempt - 1);
+        $backoff = $MAX_BACKOFF if $backoff > $MAX_BACKOFF;
+
+        print STDERR "pubmedIdToCitation: $lastError for pubmed id \"$pubmedId\","
+                     . " retrying in ${backoff}s (attempt $attempt of $MAX_ATTEMPTS)\n";
+        sleep $backoff;
+    }
+
+    die "PMC API did not return a valid response for pubmed id \"$pubmedId\""
+        . " after $MAX_ATTEMPTS attempts (last error: $lastError)."
+        . " Request URL was \"$url\"";
+}
 
 sub usage {
     print STDERR "


### PR DESCRIPTION
NCBI throttles at ~3 req/sec and a full presenter load exceeds it, so one 429 was aborting the entire DatasetPresenter load.

Switch to LWP::UserAgent so the HTTP status is visible, and retry 429/5xx five times with exponential backoff, honouring Retry-After; other 4xx still fails fast.