### PR TITLE
Inject AntibodyArray EDA gene tables; drop dead legacy graph references

### DIFF
--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
@@ -24,10 +24,6 @@ public class AntibodyArrayEDAStudy extends GenomicsEDAStudy {
         injectTemplate("antibodyArrayEdaQuestion");
         injectTemplate("antibodyArrayEdaGeneTableSql");
         injectTemplate("antibodyArrayDataTableGeneTableSql");
-        injectTemplate("antibodyArrayEdaAttributeQueriesNumeric");
-        injectTemplate("antibodyArrayEdaAttributeQueriesString");
-        injectTemplate("antibodyArrayEdaAttributeRef");
-        injectTemplate("antibodyArrayEdaAttributeCategory");
 
         setPropValue("questionName", getInternalQuestionName());
         setPropValue("searchCategory", "searchCategory-T-test-2-sample-unequal-variance");

--- a/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
+++ b/Model/src/main/java/org/apidb/apicommon/model/datasetInjector/AntibodyArrayEDAStudy.java
@@ -22,6 +22,12 @@ public class AntibodyArrayEDAStudy extends GenomicsEDAStudy {
         setPropValue("datasetDisplayName", trimmedDatasetDisplayName);
 
         injectTemplate("antibodyArrayEdaQuestion");
+        injectTemplate("antibodyArrayEdaGeneTableSql");
+        injectTemplate("antibodyArrayDataTableGeneTableSql");
+        injectTemplate("antibodyArrayEdaAttributeQueriesNumeric");
+        injectTemplate("antibodyArrayEdaAttributeQueriesString");
+        injectTemplate("antibodyArrayEdaAttributeRef");
+        injectTemplate("antibodyArrayEdaAttributeCategory");
 
         setPropValue("questionName", getInternalQuestionName());
         setPropValue("searchCategory", "searchCategory-T-test-2-sample-unequal-variance");
@@ -31,9 +37,10 @@ public class AntibodyArrayEDAStudy extends GenomicsEDAStudy {
     @Override
     public void addModelReferences() {
         super.addModelReferences();
-        addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "HostResponseGraphs");
-	addWdkReference("TranscriptRecordClasses.TranscriptRecordClass", "profile_graph", getPropValue("graphModule") + getDatasetName() );
+
         addWdkReference("TranscriptRecordClasses.TranscriptRecordClass", "question", "GeneQuestions.GenesByAntibodyArrayEdaSubset_" + this.getDatasetName());
+        addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "EdaAntibodyArrayDatasets");
+        addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "EdaAntibodyArrayGraphsDataTable");
     }
 
 }


### PR DESCRIPTION
Injector side of the AntibodyArray EDA gene tables.

**Requires** VEuPathDB/ApiCommonModel#214 (the queries, tables, ontology lines and templates). Merge together — either alone breaks the build.

## What's here

`AntibodyArrayEDAStudy` now:

- injects `antibodyArrayEdaGeneTableSql` and `antibodyArrayDataTableGeneTableSql`
- registers `EdaAntibodyArrayDatasets` and `EdaAntibodyArrayGraphsDataTable`
- **drops two dead legacy references** (see below)

## The deletions fix a live defect

Removed:

```java
addWdkReference("GeneRecordClasses.GeneRecordClass", "table", "HostResponseGraphs");
addWdkReference("TranscriptRecordClasses.TranscriptRecordClass", "profile_graph",
                getPropValue("graphModule") + getDatasetName());
```

No presenter supplies `graphModule` any more — all five antibody-array presenters carry only `AntibodyArrayEDAStudy`; the legacy `AntibodyArray` injector is commented out in three and absent in two. `DatasetInjector.getPropValue` is a bare `Map.get` returning `null`, so Java string concatenation produced `"null" + datasetName`.

`apidbtuning.datasetmodelref` in `genomicsdb_devn` currently holds exactly five junk rows as a result:

```
profile_graph | nullPlasmoDB_Crompton_Mali_AntibodyArray_RSRC
profile_graph | nullPlasmoDB_Helb_RecentExposure_AntibodyArray_RSRC
profile_graph | nullPlasmoDB_ICEMR_combined_AntibodyArray_RSRC
profile_graph | nullPlasmoDB_Kazura_Reinfection_AntibodyArray_RSRC
profile_graph | nullPlasmoDB_Loffler_Natural_Infection_AntibodyArray_RSRC
```

Nothing else in that table is `null`-prefixed. The rows clear on the next dataset injection.

## Follow-up, deliberately not here

`HostResponseGraphs` is exclusively antibody-array — also referenced by the legacy `AntibodyArray` injector and four custom PlasmoDB injectors. Now that nothing injects it for these datasets, retiring those definitions is a separate, easily-reviewable diff. Keeping it separate means the legacy path is one presenter edit away from returning if the EDA graphs need rework.

## Verification

Built on a dev instance: injection resolves for all five datasets, both queries assemble with 5 UNION branches carrying the real EDA stable ids, and executing them against `genomicsdb_devn` returns 443–1456 genes per dataset. Details in VEuPathDB/ApiCommonModel#214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)