### PR TITLE
Load category hyperlinks using the dataset's effective category

### DIFF
--- a/DatasetPresenter/src/main/java/org/apidb/apicommon/datasetPresenter/DatasetPresenterSetLoader.java
+++ b/DatasetPresenter/src/main/java/org/apidb/apicommon/datasetPresenter/DatasetPresenterSetLoader.java
@@ -369,6 +369,26 @@ public class DatasetPresenterSetLoader {
     }
   }
 
+  /**
+   * The effective category of a datasource within a presenter, in precedence order:
+   * the injector's categoryOverride attribute, then the presenter's categoryOverride
+   * element, then the datasetClassCategory prop supplied by the dataset class prop file.
+   *
+   * This single value is BOTH what lands in DatasetDatasource.category (and so what the
+   * dataset record page displays) and the key used to look up default hyperlinks in
+   * datasetLinks.xml. Computing it in two places is what let the two drift: the hyperlink
+   * lookup used only the injector attribute, which just 3 presenters in all of
+   * ApiCommonPresenters declare, so category-driven links (including every genome-browser
+   * link) silently stopped loading for ~everything.
+   */
+  String getEffectiveCategory(DatasetPresenter datasetPresenter, DatasetInjector datasetInjector) {
+    if (datasetInjector != null && datasetInjector.getCategoryOverride() != null)
+      return datasetInjector.getCategoryOverride();
+    if (datasetPresenter.getCategoryOverride() != null)
+      return datasetPresenter.getCategoryOverride();
+    return datasetPresenter.getPropValue("datasetClassCategory");
+  }
+
   void loadDatasetInjector(DatasetPresenter datasetPresenter, DatasetInjector datasetInjector, String datasetPresenterId) throws SQLException {
 
 
@@ -383,8 +403,9 @@ public class DatasetPresenterSetLoader {
       loadInjectorPropValue(datasetPresenterId, name, pv.getKey(), dataValue, injectorPropertiesStmt);
     }
 
-    if (datasetInjector.getCategoryOverride() != null) {
-      for (HyperLink link : defaultHyperLinks.getHyperLinksFromCategory(datasetInjector.getCategoryOverride()))
+    String category = getEffectiveCategory(datasetPresenter, datasetInjector);
+    if (category != null && !category.isEmpty()) {
+      for (HyperLink link : defaultHyperLinks.getHyperLinksFromCategory(category))
         loadLink(datasetPresenterId, link, linkStmt);
     }
 
@@ -476,12 +497,9 @@ public class DatasetPresenterSetLoader {
 
     for (Datasource datasource : datasetPresenter.getDatasources()) {
       DatasetInjector di = datasetPresenter.findInjectorByName(datasource.getName());
-      String dpCategory = datasetPresenter.getPropValue("datasetClassCategory");
-      if (datasetPresenter.getCategoryOverride() != null) dpCategory = datasetPresenter.getCategoryOverride();
-      String diCategory = di == null || di.getCategoryOverride() == null? null : di.getCategoryOverride();
       loadDatasetDatasource(datasource.getDatasourceId(),
               datasetPresenterId,
-              diCategory == null? dpCategory : diCategory,
+              getEffectiveCategory(datasetPresenter, di),
               datasource.getProjectId(),
               datasource.getName(),
               datasource.getTaxonId()


### PR DESCRIPTION
## Problem

Dataset record pages lost their "Explore this dataset within this website" links — including every genome-browser (JBrowse) link — for nearly all datasets.

`datasetLinks.xml` associates curated URLs to datasets by **category**:

```xml
<link category="CHIP Seq">
  <text>View/Download this Data Set in the DEFAULT_PROJECT Genome Browser</text>
  <url><![CDATA[/a/app/jbrowse?loc=DEFAULT_SEQUENCE&data=/a/service/jbrowse/tracks/DEFAULT_ORG_ABBREV&tracks=gene%2CDEFAULT_DATASET_NAME%20Density...]]></url>
</link>
```

Since #62, `loadDatasetInjector` looked those up with `datasetInjector.getCategoryOverride()` alone — the `categoryOverride=` **attribute** on `<templateInjector>`, which exactly **3 presenters in all of ApiCommonPresenters** declare. The presenter-level `<categoryOverride>` *element* (117 uses) and the `datasetClassCategory` prop were both ignored.

Meanwhile `loadDatasetPresenter`, ~110 lines away, computed the category correctly when writing `DatasetDatasource.category` — the value the page actually displays. Two copies of "what category is this dataset", silently disagreeing.

## Evidence (FungiDB b71, `genomicsdb_071n`)

```
datasetdatasource.category for cneoH99_Homer_Compare_Genotypes_chipSeq_RSRC = 'CHIP Seq'   <- matches datasetLinks.xml exactly
datasethyperlink rows for it                                                = 1 (its own <link>, no category link)
FungiDB datasets with any internal ('/%') link                              = 5, all hand-written <link> elements
datasethyperlink rows originating from datasetLinks.xml, entire appDb       = 2
```

Both of those 2 belong to `HPI_Lee_Gambian_ebi_rnaSeq_RSRC` — one of the three presenters carrying the injector attribute. All 15 "CHIP Seq" datasets and all 234 RNASeq datasets had zero `genomicsInternal` links.

## Change

Extract the precedence — injector attribute → presenter element → `datasetClassCategory` prop — into `getEffectiveCategory()` and call it from both sites.

- `DatasetDatasource.category` is **unchanged**: the precedence is identical, including the existing quirk that an empty `<categoryOverride></categoryOverride>` beats a real `datasetClassCategory`.
- The hyperlink branch additionally guards `!isEmpty()`, so a blank override doesn't issue a `""` lookup.
- No new duplicate link rows: `loadDatasetInjector` runs once per injector, and multi-injector presenters are already forced by `DatasetPresenter.validate()` to carry per-injector overrides, so they take the injector branch before and after.

## Testing

`wb full` on the FungiDB dev instance compiles clean (`ebrc-model-common-datasetpresenter-1.0.0.jar` rebuilt).

Behavior is **not** verified end-to-end: this changes what the presenter loader writes into `apidb.DatasetHyperlink`, which is a data-load step, so it takes effect on the next presenter load into an appDb, not on a `wb` target.

## Two known downstream gaps, not addressed here

Rows this fix starts writing still won't render correctly until:

1. `DatasetTables.References` (`Model/lib/wdk/model/records/datasetRecordQueries.xml:706`) selects from raw `apidbtuning.DatasetHyperlink`, not the macro-expanded `apidbtuning.GenomicsInternalHyperlink` — so `DEFAULT_DATASET_NAME` etc. reach the page literally. The tuning table is read by nothing.
2. `GenomicsInternalHyperlink` (`ApiCommonModel .../apiTuningManager.xml:2231`) NULLs every URL: 12 nested `replace()` calls over `LEFT JOIN`ed columns, and one NULL argument nulls the whole expression. All 119 rows currently have a NULL url. Needs `coalesce` per macro source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)